### PR TITLE
0MB no longer visible, adding clarity

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/anime/SelectorDialogFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/anime/SelectorDialogFragment.kt
@@ -241,10 +241,11 @@ class SelectorDialogFragment : BottomSheetDialogFragment() {
                 )
                 dismiss()
             }
-            if (video.format == VideoType.CONTAINER) {
+             if (video.format == VideoType.CONTAINER) {
                 binding.urlSize.visibility = if (video.size != null) View.VISIBLE else View.GONE
                 binding.urlSize.text =
-                    (if (video.extraNote != null) " : " else "") + DecimalFormat("#.##").format(video.size ?: 0).toString() + " MB"
+                // if video size is null or 0, show "Unknown Size" else show the size in MB
+                    (if (video.extraNote != null) " : " else "") + (if (video.size == 0) "Unknown Size" else (DecimalFormat("#.##").format(video.size ?: 0).toString()+ " MB")) 
             }
             else {
                 binding.urlQuality.text = "Multi Quality"

--- a/app/src/main/java/ani/dantotsu/others/AppUpdater.kt
+++ b/app/src/main/java/ani/dantotsu/others/AppUpdater.kt
@@ -104,7 +104,8 @@ object AppUpdater {
                         0    -> s.toDouble() * 100
                         1    -> s.toDouble() * 10
                         2    -> s.toDouble()
-                        else -> s.toDoubleOrNull()?: 0.0
+                        // this might encounter problems where it 1.0.0.1b == 1.0.0.1
+                        else -> s.filter { it.isDigit() }.toDoubleOrNull() ?: 0.0
                     }
                 }.sum()
             }


### PR DESCRIPTION
Previously, if the video was zero megabytes, it would show "0 MB", I've changed this to now show "Unknown Size".

See [Issue 8](https://github.com/rebelonion/Dantotsu/issues/8)