### PR TITLE
letters suffixing version string now ignored

### DIFF
--- a/app/src/main/java/ani/dantotsu/others/AppUpdater.kt
+++ b/app/src/main/java/ani/dantotsu/others/AppUpdater.kt
@@ -104,7 +104,8 @@ object AppUpdater {
                         0    -> s.toDouble() * 100
                         1    -> s.toDouble() * 10
                         2    -> s.toDouble()
-                        else -> s.toDoubleOrNull()?: 0.0
+                        // this might encounter problems where it 1.0.0.1b == 1.0.0.1
+                        else -> s.filter { it.isDigit() }.toDoubleOrNull() ?: 0.0
                     }
                 }.sum()
             }


### PR DESCRIPTION
When on a prerelease version, the app updater has issues comparing versions. This is because, what on a stable branch would be:

1.0.0
(100+00+0) = 100
prerelease would be 
100 + 00 + 0 + null = 100 as opposed to 101

This does have another issue though, that being that it would be unable to differentiate between 1.0.0.1b and 1.0.0.1

See [Discord Issue](https://discord.com/channels/1163949787213746248/1170200603163635744/1170200603163635744)