### PR TITLE
making double tap zoom lower in manga reader

### DIFF
--- a/app/src/main/res/layout/activity_manga_reader.xml
+++ b/app/src/main/res/layout/activity_manga_reader.xml
@@ -22,7 +22,7 @@
             android:id="@+id/mangaReaderRecyclerContainer"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:gest_doubleTapZoom="3"
+            app:gest_doubleTapZoom="2"
             app:gest_maxZoom="6"
             app:gest_restrictRotation="true"
             app:gest_rotationEnabled="true">


### PR DESCRIPTION
Double tap zoom is currently rather high, lowering it to be 33% of maximum zoom as opposed to 50% 

[See Discord Suggestion](https://discord.com/channels/1163949787213746248/1165496150233718884/1168448587542298716)