### PR TITLE
when video size is 0mb, display unknown size instead

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/anime/SelectorDialogFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/anime/SelectorDialogFragment.kt
@@ -244,7 +244,8 @@ class SelectorDialogFragment : BottomSheetDialogFragment() {
             if (video.format == VideoType.CONTAINER) {
                 binding.urlSize.visibility = if (video.size != null) View.VISIBLE else View.GONE
                 binding.urlSize.text =
-                    (if (video.extraNote != null) " : " else "") + DecimalFormat("#.##").format(video.size ?: 0).toString() + " MB"
+                    // if video size is null or 0, show "Unknown Size" else show the size in MB
+                    (if (video.extraNote != null) " : " else "") + (if (video.size == 0) "Unknown Size" else (DecimalFormat("#.##").format(video.size ?: 0).toString()+ " MB")) 
             }
             else {
                 binding.urlQuality.text = "Multi Quality"


### PR DESCRIPTION
Forgive me if it's bad practice to create a second pr, I wasn't sure on how to remove the unnecessary commit from the original one

Previously, if the video was zero megabytes, it would show "0 MB", I've changed this to now show "Unknown Size".

See [Issue 8](https://github.com/rebelonion/Dantotsu/issues/8)