### PR TITLE
Updated Support For Android 14 (API 34) (WIP)

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
@@ -7,6 +7,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -14,6 +15,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.core.math.MathUtils.clamp
@@ -96,13 +98,15 @@ open class MangaReadFragment : Fragment() {
         return _binding?.root
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val intentFilter = IntentFilter().apply {
             addAction(ACTION_DOWNLOAD_STARTED)
             addAction(ACTION_DOWNLOAD_FINISHED)
         }
-        requireContext().registerReceiver(downloadStatusReceiver, intentFilter)
+
+        requireContext().registerReceiver(downloadStatusReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
         binding.animeSourceRecycler.updatePadding(bottom = binding.animeSourceRecycler.paddingBottom + navBarHeight)
         screenWidth = resources.displayMetrics.widthPixels.dp
 

--- a/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
@@ -106,10 +106,13 @@ open class MangaReadFragment : Fragment() {
             addAction(ACTION_DOWNLOAD_FINISHED)
         }
 
+<<<<<<< Updated upstream
         requireContext().registerReceiver(downloadStatusReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
+=======
+        ContextCompat.registerReceiver(requireContext(), downloadStatusReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+>>>>>>> Stashed changes
         binding.animeSourceRecycler.updatePadding(bottom = binding.animeSourceRecycler.paddingBottom + navBarHeight)
         screenWidth = resources.displayMetrics.widthPixels.dp
-
 
         var maxGridSize = (screenWidth / 100f).roundToInt()
         maxGridSize = max(4, maxGridSize - (maxGridSize % 2))

--- a/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
@@ -98,7 +98,6 @@ open class MangaReadFragment : Fragment() {
         return _binding?.root
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val intentFilter = IntentFilter().apply {
@@ -106,11 +105,8 @@ open class MangaReadFragment : Fragment() {
             addAction(ACTION_DOWNLOAD_FINISHED)
         }
 
-<<<<<<< Updated upstream
-        requireContext().registerReceiver(downloadStatusReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
-=======
         ContextCompat.registerReceiver(requireContext(), downloadStatusReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
->>>>>>> Stashed changes
+        
         binding.animeSourceRecycler.updatePadding(bottom = binding.animeSourceRecycler.paddingBottom + navBarHeight)
         screenWidth = resources.displayMetrics.widthPixels.dp
 


### PR DESCRIPTION
Mainly updates the context receiver line of code to adhere to the API 34 guidelines, by adding Context.RECEIVER_NOT_EXPORTED: https://developer.android.com/about/versions/14/behavior-changes-14