### PR TITLE
use episode titles from kitsu

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/anime/AnimeWatchFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/anime/AnimeWatchFragment.kt
@@ -208,12 +208,9 @@ class AnimeWatchFragment : Fragment() {
                         }
                         if (media.anime?.kitsuEpisodes != null) {
                             if (media.anime!!.kitsuEpisodes!!.containsKey(i)) {
-                                episode.desc =
-                                    episode.desc ?: media.anime!!.kitsuEpisodes!![i]?.desc
-                                episode.title =
-                                    episode.title ?: media.anime!!.kitsuEpisodes!![i]?.title
-                                episode.thumb =
-                                    episode.thumb ?: media.anime!!.kitsuEpisodes!![i]?.thumb
+                                    episode.desc = media.anime!!.kitsuEpisodes!![i]?.desc ?: episode.desc
+                                    episode.title = media.anime!!.kitsuEpisodes!![i]?.title ?: episode.title
+                                    episode.thumb = media.anime!!.kitsuEpisodes!![i]?.thumb
                                             ?: FileUrl[media.cover]
                             }
                         }


### PR DESCRIPTION
use episode titles from kitsu if kitsu doesn't have episode titles use episode titles from anime source

all the sources except aniwave, aniwatch, kaido, doesn't provide episode titles so using the episode titles from kitsu would be great

you can also try this artifact build and test it yourself
https://github.com/Yutatsu0/Dantotsu/actions/runs/7595023003/artifacts/1183041478