### PR TITLE
added episode duration formatting

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/MediaInfoFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/MediaInfoFragment.kt
@@ -95,8 +95,30 @@ class MediaInfoFragment : Fragment() {
                 binding.mediaInfoStart.text = media.startDate?.toString() ?: "??"
                 binding.mediaInfoEnd.text = media.endDate?.toString() ?: "??"
                 if (media.anime != null) {
-                    binding.mediaInfoDuration.text =
-                        if (media.anime.episodeDuration != null) media.anime.episodeDuration.toString() else "??"
+                    val episodeDuration = media.anime.episodeDuration
+
+binding.mediaInfoDuration.text = when {
+    episodeDuration != null -> {
+        val hours = episodeDuration / 60
+        val minutes = episodeDuration % 60
+
+        val formattedDuration = buildString {
+            if (hours > 0) {
+                append("$hours hour")
+                if (hours > 1) append("s")
+            }
+
+            if (minutes > 0) {
+                if (hours > 0) append(", ")
+                append("$minutes min")
+                if (minutes > 1) append("s")
+            }
+        }
+
+        formattedDuration
+    }
+    else -> "??"
+}
                     binding.mediaInfoDurationContainer.visibility = View.VISIBLE
                     binding.mediaInfoSeasonContainer.visibility = View.VISIBLE
                     binding.mediaInfoSeason.text =

--- a/app/src/main/res/layout/fragment_media_info.xml
+++ b/app/src/main/res/layout/fragment_media_info.xml
@@ -145,13 +145,6 @@
                             android:layout_weight="1"
                             android:fontFamily="@font/poppins_bold"
                             android:textAlignment="textEnd" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:fontFamily="@font/poppins_bold"
-                            android:text="@string/min"
-                            android:textAlignment="textEnd" />
                     </TableRow>
 
                     <TableRow


### PR DESCRIPTION
currently the average duration is in minutes so now

if it's like minutes for example 24 mins
if it's like hour and minutes for example 1 hour, 53 mins
if it's more than one hour and minutes for example 2 hours, 14 mins

here are some screenshots comparison

before
![IMG_20240126_235420](https://github.com/rebelonion/Dantotsu/assets/126276749/40683d37-4939-4959-9caa-094dd0b72cfe)
![IMG_20240126_235320](https://github.com/rebelonion/Dantotsu/assets/126276749/839a0b34-8f11-4a01-98f7-25762c16f703)
![IMG_20240126_235217](https://github.com/rebelonion/Dantotsu/assets/126276749/fae75917-bb28-408a-ab67-cb2ae441ba99)
after
![IMG_20240126_235001](https://github.com/rebelonion/Dantotsu/assets/126276749/a21536e0-3893-4815-ac1e-23a3ee197355)
![IMG_20240126_234902](https://github.com/rebelonion/Dantotsu/assets/126276749/4b16ea91-255b-4890-a0a5-4ec746c4b3e3)
![IMG_20240126_234720](https://github.com/rebelonion/Dantotsu/assets/126276749/731cbed9-d2f8-4f7c-a6ed-36ba755969e7)