### PR TITLE
Discord Status Switcher

### DIFF
--- a/app/src/main/java/ani/dantotsu/connections/discord/RPC.kt
+++ b/app/src/main/java/ani/dantotsu/connections/discord/RPC.kt
@@ -2,6 +2,8 @@ package ani.dantotsu.connections.discord
 
 import ani.dantotsu.connections.discord.serializers.Activity
 import ani.dantotsu.connections.discord.serializers.Presence
+import ani.dantotsu.settings.saving.PrefManager
+import ani.dantotsu.settings.saving.PrefName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -81,7 +83,7 @@ open class RPC(val token: String, val coroutineContext: CoroutineContext) {
                     ),
                     afk = true,
                     since = data.startTimestamp,
-                    status = data.status
+                    status = PrefManager.getVal(PrefName.DiscordStatus)
                 )
             ))
         }

--- a/app/src/main/java/ani/dantotsu/settings/SettingsActivity.kt
+++ b/app/src/main/java/ani/dantotsu/settings/SettingsActivity.kt
@@ -14,8 +14,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AnimationUtils
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
+import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
@@ -805,7 +807,41 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
                     restartMainActivity.isEnabled = true
                     reload()
                 }
+
+                val imageSwitcher: ImageView = findViewById(R.id.imageSwitcher)
+                imageSwitcher.visibility = View.VISIBLE
+                val temp3: String = PrefManager.getVal(PrefName.DiscordStatus)
+                var temp5 = when (temp3) {
+                    "online" -> R.drawable.discord_status_online
+                    "idle" -> R.drawable.discord_status_idle
+                    "dnd" -> R.drawable.discord_status_dnd
+                    else -> R.drawable.discord_status_online
+                }
+                imageSwitcher.setImageResource(temp5)
+
+                val zoomInAnimation = AnimationUtils.loadAnimation(this, R.anim.bounce_zoom)
+                imageSwitcher.setOnClickListener {
+                    temp5 = when (temp5) {
+                        R.drawable.discord_status_online -> R.drawable.discord_status_idle
+                        R.drawable.discord_status_idle -> R.drawable.discord_status_dnd
+                        R.drawable.discord_status_dnd -> R.drawable.discord_status_online
+                        else -> R.drawable.discord_status_online
+                    }
+
+                    val status = when (temp5) {
+                        R.drawable.discord_status_online -> "online"
+                        R.drawable.discord_status_idle -> "idle"
+                        R.drawable.discord_status_dnd -> "dnd"
+                        else -> "online"
+                    }
+
+                    PrefManager.setVal(PrefName.DiscordStatus, status)
+                    imageSwitcher.setImageResource(temp5)
+                    imageSwitcher.startAnimation(zoomInAnimation)
+                }
             } else {
+                val imageSwitcher: ImageView = findViewById(R.id.imageSwitcher)
+                imageSwitcher.visibility = View.GONE
                 binding.settingsDiscordAvatar.setImageResource(R.drawable.ic_round_person_24)
                 binding.settingsDiscordUsername.visibility = View.GONE
                 binding.settingsDiscordLogin.setText(R.string.login)

--- a/app/src/main/java/ani/dantotsu/settings/saving/Preferences.kt
+++ b/app/src/main/java/ani/dantotsu/settings/saving/Preferences.kt
@@ -144,6 +144,7 @@ enum class PrefName(val data: Pref) {  //TODO: Split this into multiple files
     //Irrelevant
     Incognito(Pref(Location.Irrelevant, Boolean::class, false)),
     OfflineMode(Pref(Location.Irrelevant, Boolean::class, false)),
+    DiscordStatus(Pref(Location.Irrelevant, String::class, "online")),
     DownloadsKeys(Pref(Location.Irrelevant, String::class, "")),
     NovelLastExtCheck(Pref(Location.Irrelevant, Long::class, 0L)),
     SomethingSpecial(Pref(Location.Irrelevant, Boolean::class, false)),

--- a/app/src/main/res/anim/bounce_zoom.xml
+++ b/app/src/main/res/anim/bounce_zoom.xml
@@ -1,0 +1,9 @@
+<scale xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromXScale="0.3"
+    android:toXScale="1.0"
+    android:fromYScale="0.3"
+    android:toYScale="1.0"
+    android:pivotX="50%"
+    android:pivotY="50%"
+    android:duration="1000"
+    android:interpolator="@android:anim/overshoot_interpolator"/>

--- a/app/src/main/res/drawable/discord_status_dnd.xml
+++ b/app/src/main/res/drawable/discord_status_dnd.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#EC3B37" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM16,13H8c-0.55,0 -1,-0.45 -1,-1l0,0c0,-0.55 0.45,-1 1,-1h8c0.55,0 1,0.45 1,1l0,0C17,12.55 16.55,13 16,13z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/discord_status_idle.xml
+++ b/app/src/main/res/drawable/discord_status_idle.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FF9F09" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,3c4.97,0 9,4.03 9,9s-4.03,9 -9,9s-9,-4.03 -9,-9c0,-0.46 0.04,-0.92 0.1,-1.36c0.98,1.37 2.58,2.26 4.4,2.26c2.98,0 5.4,-2.42 5.4,-5.4c0,-1.81 -0.89,-3.42 -2.26,-4.4C11.08,3.04 11.54,3 12,3L12,3z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/discord_status_online.xml
+++ b/app/src/main/res/drawable/discord_status_online.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#50A361" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -238,7 +238,8 @@
                     android:id="@+id/settingsDiscordLoginContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:orientation="horizontal"
+                    tools:ignore="ExtraText">
 
                     <ImageView
                         android:layout_width="31dp"
@@ -281,6 +282,14 @@
                             android:textSize="14sp" />
 
                     </LinearLayout>
+
+                    <ImageView
+                        android:id="@+id/imageSwitcher"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/discord_status_idle"
+                        android:onClick="onImageClicked"
+                        android:padding="16dp" />
 
                     <com.google.android.material.card.MaterialCardView
                         android:id="@+id/settingsDiscordAvatarContainer"


### PR DESCRIPTION
- changes the discord status in the rich presence
- selection between online, idle or dnd for discord
- only viewable for users that are logged in discord

**Note:**
The discord client status overrides the rich presence status.
→ This means that if you have discord opened it will use the status of your discord client and not the status of set by dantotsu. This is set by discord and not possible to bypass. The status set by dantotsu will not get overridden if discord is closed on every logged in device.