### PR TITLE
A few build and navigation bar improvements

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -89,6 +89,7 @@ jobs:
           path: "app/build/outputs/apk/google/alpha/app-google-alpha.apk"
             
     - name: Upload APK to Discord and Telegram
+      if: ${{ github.repository == 'rebelonion/Dantotsu' }}
       shell: bash
       run: |
         #Discord

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -904,16 +904,16 @@ fun toast(string: String?) {
     }
 }
 
-fun snackString(s: String?, activity: Activity? = null, clipboard: String? = null) {
+fun snackString(s: String?, activity: Activity? = null, clipboard: String? = null) : Snackbar? {
     try { //I have no idea why this sometimes crashes for some people...
         if (s != null) {
             (activity ?: currActivity())?.apply {
+                val snackBar = Snackbar.make(
+                    window.decorView.findViewById(android.R.id.content),
+                    s,
+                    Snackbar.LENGTH_SHORT
+                )
                 runOnUiThread {
-                    val snackBar = Snackbar.make(
-                        window.decorView.findViewById(android.R.id.content),
-                        s,
-                        Snackbar.LENGTH_SHORT
-                    )
                     snackBar.view.apply {
                         updateLayoutParams<FrameLayout.LayoutParams> {
                             gravity = (Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM)
@@ -933,6 +933,7 @@ fun snackString(s: String?, activity: Activity? = null, clipboard: String? = nul
                     }
                     snackBar.show()
                 }
+                return snackBar
             }
             logger(s)
         }
@@ -940,6 +941,7 @@ fun snackString(s: String?, activity: Activity? = null, clipboard: String? = nul
         logger(e.stackTraceToString())
         Injekt.get<CrashlyticsInterface>().logException(e)
     }
+    return null
 }
 
 open class NoPaddingArrayAdapter<T>(context: Context, layoutId: Int, items: List<T>) :

--- a/app/src/main/java/ani/dantotsu/MainActivity.kt
+++ b/app/src/main/java/ani/dantotsu/MainActivity.kt
@@ -22,6 +22,9 @@ import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.animation.doOnEnd
 import androidx.core.content.ContextCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.doOnAttach
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
@@ -349,6 +352,16 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        WindowInsetsControllerCompat(window, window.decorView).let { controller ->
+            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+        }
+    }
 
     //ViewPager
     private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Lifecycle) :

--- a/app/src/main/java/ani/dantotsu/MainActivity.kt
+++ b/app/src/main/java/ani/dantotsu/MainActivity.kt
@@ -52,6 +52,8 @@ import ani.dantotsu.settings.saving.PrefName
 import ani.dantotsu.settings.saving.SharedPreferenceBooleanLiveData
 import ani.dantotsu.subcriptions.Subscription.Companion.startSubscription
 import ani.dantotsu.themes.ThemeManager
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import eu.kanade.domain.source.service.SourcePreferences
 import io.noties.markwon.Markwon
 import io.noties.markwon.SoftBreakAddsNewLinePlugin
@@ -144,7 +146,20 @@ class MainActivity : AppCompatActivity() {
                 finish()
             }
             doubleBackToExitPressedOnce = true
-            snackString(this@MainActivity.getString(R.string.back_to_exit))
+            WindowInsetsControllerCompat(window, window.decorView)
+                .show(WindowInsetsCompat.Type.navigationBars())
+            snackString(this@MainActivity.getString(R.string.back_to_exit)).apply {
+                this?.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+                    override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                        super.onDismissed(transientBottomBar, event)
+                        WindowInsetsControllerCompat(window, window.decorView).let { controller ->
+                            controller.systemBarsBehavior =
+                                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                            controller.hide(WindowInsetsCompat.Type.navigationBars())
+                        }
+                    }
+                })
+            }
             Handler(Looper.getMainLooper()).postDelayed(
                 { doubleBackToExitPressedOnce = false },
                 2000
@@ -359,7 +374,7 @@ class MainActivity : AppCompatActivity() {
 
         WindowInsetsControllerCompat(window, window.decorView).let { controller ->
             controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            controller.hide(WindowInsetsCompat.Type.systemBars())
+            controller.hide(WindowInsetsCompat.Type.navigationBars())
         }
     }
 

--- a/app/src/main/java/ani/dantotsu/connections/anilist/AnilistQueries.kt
+++ b/app/src/main/java/ani/dantotsu/connections/anilist/AnilistQueries.kt
@@ -281,7 +281,7 @@ class AnilistQueries {
                 } else {
                     if (currContext()?.let { isOnline(it) } == true) {
                         snackString(currContext()?.getString(R.string.error_getting_data))
-                    }
+                    } else { }
                 }
             }
             val mal = async {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,5 +5,5 @@ dependencyResolutionManagement {
         maven("https://jitpack.io")
     }
 }
-rootProject.name = "dantotsu"
+rootProject.name = "Dantotsu"
 include(":app")


### PR DESCRIPTION
This filters the build action for publishing to Discord and Telegram, which allows forks to add the necessary keys and build local alpha tests without needing to make use of the "continue-on-error" clause.

The root project name was matched to the repository to allow building without having to either rename the folder after a clone.

The ability to hide the navigation bar on the main screen was added to provide a little more space and a cleaner look. This can be placed behind a user preference. It was only applied to the main screen. All preference screens and other areas where you would typically use the navigation bar to actually navigate the UI were left as is.