### PR TITLE
Cleaning up navigation

### DIFF
--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -135,7 +135,7 @@ fun logger(e: Any?, print: Boolean = true) {
 }
 
 
-fun initActivity(a: Activity) {
+fun initActivityTheme(a: Activity) {
     val window = a.window
     WindowCompat.setDecorFitsSystemWindows(window, false)
     val darkMode = PrefManager.getVal<Int>(PrefName.DarkMode)

--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -184,6 +184,15 @@ fun Activity.hideSystemBars() {
     }
 }
 
+fun Activity.setNavigationTheme() {
+    val a = TypedValue()
+    theme.resolveAttribute(android.R.attr.colorBackground, a, true)
+    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && a.isColorType)
+        || (a.type >= TypedValue.TYPE_FIRST_COLOR_INT && a.type <= TypedValue.TYPE_LAST_COLOR_INT)) {
+        window.navigationBarColor = a.data
+    }
+}
+
 open class BottomSheetDialogFragment : BottomSheetDialogFragment() {
     override fun onStart() {
         super.onStart()

--- a/app/src/main/java/ani/dantotsu/MainActivity.kt
+++ b/app/src/main/java/ani/dantotsu/MainActivity.kt
@@ -357,6 +357,11 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        window.navigationBarColor = getColor(android.R.color.transparent)
+    }
+
     //ViewPager
     private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Lifecycle) :
         FragmentStateAdapter(fragmentManager, lifecycle) {

--- a/app/src/main/java/ani/dantotsu/MainActivity.kt
+++ b/app/src/main/java/ani/dantotsu/MainActivity.kt
@@ -209,7 +209,7 @@ class MainActivity : AppCompatActivity() {
 
 
         binding.root.doOnAttach {
-            initActivity(this)
+            initActivityTheme(this)
             selectedOption = if (fragment != null) {
                 when (fragment) {
                     AnimeFragment::class.java.name -> 0
@@ -359,6 +359,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        initActivityTheme(this)
+        binding.includedNavbar.navbarContainer.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            bottomMargin = navBarHeight
+        }
         window.navigationBarColor = getColor(android.R.color.transparent)
     }
 

--- a/app/src/main/java/ani/dantotsu/MainActivity.kt
+++ b/app/src/main/java/ani/dantotsu/MainActivity.kt
@@ -146,24 +146,14 @@ class MainActivity : AppCompatActivity() {
                 finish()
             }
             doubleBackToExitPressedOnce = true
-            WindowInsetsControllerCompat(window, window.decorView)
-                .show(WindowInsetsCompat.Type.navigationBars())
             snackString(this@MainActivity.getString(R.string.back_to_exit)).apply {
                 this?.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
                     override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
                         super.onDismissed(transientBottomBar, event)
-                        WindowInsetsControllerCompat(window, window.decorView).let { controller ->
-                            controller.systemBarsBehavior =
-                                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                            controller.hide(WindowInsetsCompat.Type.navigationBars())
-                        }
+                        doubleBackToExitPressedOnce = false
                     }
                 })
             }
-            Handler(Looper.getMainLooper()).postDelayed(
-                { doubleBackToExitPressedOnce = false },
-                2000
-            )
         }
 
         val preferences: SourcePreferences = Injekt.get()
@@ -364,17 +354,6 @@ class MainActivity : AppCompatActivity() {
                     Helper.downloadManager(this@MainActivity).removeDownload(download.request.id)
                 }
             }
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-
-        WindowInsetsControllerCompat(window, window.decorView).let { controller ->
-            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            controller.hide(WindowInsetsCompat.Type.navigationBars())
         }
     }
 

--- a/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
@@ -601,6 +601,7 @@ open class MangaReadFragment : Fragment(), ScanlatorSelectionListener {
         super.onResume()
         binding.mediaInfoProgressBar.visibility = progress
         binding.animeSourceRecycler.layoutManager?.onRestoreInstanceState(state)
+        requireActivity().setNavigationTheme()
     }
 
     override fun onPause() {

--- a/app/src/main/java/ani/dantotsu/media/manga/mangareader/MangaReaderActivity.kt
+++ b/app/src/main/java/ani/dantotsu/media/manga/mangareader/MangaReaderActivity.kt
@@ -285,7 +285,7 @@ class MangaReaderActivity : AppCompatActivity() {
             binding.mangaReaderNextChapter.performClick()
         }
         binding.mangaReaderNextChapter.setOnClickListener {
-            if (defaultSettings.direction == RIGHT_TO_LEFT) {
+            if (defaultSettings.direction == RIGHT_TO_LEFT || defaultSettings.direction == BOTTOM_TO_TOP) {
                 if (currentChapterIndex > 0) change(currentChapterIndex - 1)
                 else snackString(getString(R.string.first_chapter))
             } else {
@@ -298,7 +298,7 @@ class MangaReaderActivity : AppCompatActivity() {
             binding.mangaReaderPreviousChapter.performClick()
         }
         binding.mangaReaderPreviousChapter.setOnClickListener {
-            if (defaultSettings.direction == RIGHT_TO_LEFT) {
+            if (defaultSettings.direction == RIGHT_TO_LEFT || defaultSettings.direction == BOTTOM_TO_TOP) {
                 if (chaptersArr.size > currentChapterIndex + 1) progress { change(currentChapterIndex + 1) }
                 else snackString(getString(R.string.next_chapter_not_found))
             } else {
@@ -315,7 +315,7 @@ class MangaReaderActivity : AppCompatActivity() {
                 PrefManager.setCustomVal("${media.id}_current_chp", chap.number)
                 currentChapterIndex = chaptersArr.indexOf(chap.number)
                 binding.mangaReaderChapterSelect.setSelection(currentChapterIndex)
-                if (defaultSettings.direction == RIGHT_TO_LEFT) {
+                if (defaultSettings.direction == RIGHT_TO_LEFT || defaultSettings.direction == BOTTOM_TO_TOP) {
                     binding.mangaReaderNextChap.text =
                         chaptersTitleArr.getOrNull(currentChapterIndex - 1) ?: ""
                     binding.mangaReaderPrevChap.text =
@@ -439,6 +439,10 @@ class MangaReaderActivity : AppCompatActivity() {
         if ((defaultSettings.direction == TOP_TO_BOTTOM || defaultSettings.direction == BOTTOM_TO_TOP)) {
             binding.mangaReaderSwipy.vertical = true
             if (defaultSettings.direction == TOP_TO_BOTTOM) {
+                binding.mangaReaderNextChap.text =
+                    chaptersTitleArr.getOrNull(currentChapterIndex + 1) ?: ""
+                binding.mangaReaderPrevChap.text =
+                    chaptersTitleArr.getOrNull(currentChapterIndex - 1) ?: ""
                 binding.BottomSwipeText.text = chaptersTitleArr.getOrNull(currentChapterIndex + 1)
                     ?: getString(R.string.no_chapter)
                 binding.TopSwipeText.text = chaptersTitleArr.getOrNull(currentChapterIndex - 1)
@@ -450,6 +454,10 @@ class MangaReaderActivity : AppCompatActivity() {
                     binding.mangaReaderNextChapter.performClick()
                 }
             } else {
+                binding.mangaReaderNextChap.text =
+                    chaptersTitleArr.getOrNull(currentChapterIndex - 1) ?: ""
+                binding.mangaReaderPrevChap.text =
+                    chaptersTitleArr.getOrNull(currentChapterIndex + 1) ?: ""
                 binding.BottomSwipeText.text = chaptersTitleArr.getOrNull(currentChapterIndex - 1)
                     ?: getString(R.string.no_chapter)
                 binding.TopSwipeText.text = chaptersTitleArr.getOrNull(currentChapterIndex + 1)
@@ -729,7 +737,7 @@ class MangaReaderActivity : AppCompatActivity() {
                 val screenWidth = Resources.getSystem().displayMetrics.widthPixels
                 //if in the 1st 1/5th of the screen width, left and lower than 1/5th of the screen height, left
                 if (screenWidth / 5 in x + 1..<y) {
-                    pressLocation = if (defaultSettings.direction == RIGHT_TO_LEFT) {
+                    pressLocation = if (defaultSettings.direction == RIGHT_TO_LEFT || defaultSettings.direction == BOTTOM_TO_TOP) {
                         pressPos.RIGHT
                     } else {
                         pressPos.LEFT
@@ -737,7 +745,7 @@ class MangaReaderActivity : AppCompatActivity() {
                 }
                 //if in the last 1/5th of the screen width, right and lower than 1/5th of the screen height, right
                 else if (x > screenWidth - screenWidth / 5 && y > screenWidth / 5) {
-                    pressLocation = if (defaultSettings.direction == RIGHT_TO_LEFT) {
+                    pressLocation = if (defaultSettings.direction == RIGHT_TO_LEFT || defaultSettings.direction == BOTTOM_TO_TOP) {
                         pressPos.LEFT
                     } else {
                         pressPos.RIGHT

--- a/app/src/main/java/ani/dantotsu/settings/DevelopersDialogFragment.kt
+++ b/app/src/main/java/ani/dantotsu/settings/DevelopersDialogFragment.kt
@@ -26,6 +26,12 @@ class DevelopersDialogFragment : BottomSheetDialogFragment() {
             "https://github.com/aayush2622"
         ),
         Developer(
+            "AbandonedCart",
+            "https://avatars.githubusercontent.com/u/1173913?v=4",
+            "Contributor",
+            "https://github.com/AbandonedCart"
+        ),
+        Developer(
             "Sadwhy",
             "https://avatars.githubusercontent.com/u/99601717?v=4",
             "Contributor",

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,10 +1,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.Base" parent="Theme.Material3.DayNight">
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">?android:colorBackground</item>
         <item name="android:windowTranslucentStatus">false</item>
-        <item name="android:windowTranslucentNavigation">true</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="elevationOverlayEnabled">false</item>
         <item name="windowActionBar">false</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,6 +4,7 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">?android:colorBackground</item>
         <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowTranslucentNavigation">true</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="elevationOverlayEnabled">false</item>
         <item name="windowActionBar">false</item>


### PR DESCRIPTION
When I submitted the previous PR to hide the navigation bar on the main screen, I hadn't noticed the hidden attempt to do it using now deprecated methods. While the methods were still working for quite a long time after being deprecated, parts became obsolete in one of the last two or three Android versions.

This fixes a bunch of dead code with more future-poof methods.

This also adds the same conversions for right to left to the bottom to top. It doesn't fix the paged scrolling inversion, but sets everything else the way it needs to be for when that is resolved.