### PR TITLE
fix: reapply theme to each init call

### DIFF
--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -174,6 +174,7 @@ fun initActivity(a: Activity) {
                 navBarHeight = insets.bottom
             }
         }
+    if (a !is MainActivity) a.setNavigationTheme()
 }
 
 fun Activity.hideSystemBars() {
@@ -185,11 +186,11 @@ fun Activity.hideSystemBars() {
 }
 
 fun Activity.setNavigationTheme() {
-    val a = TypedValue()
-    theme.resolveAttribute(android.R.attr.colorBackground, a, true)
-    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && a.isColorType)
-        || (a.type >= TypedValue.TYPE_FIRST_COLOR_INT && a.type <= TypedValue.TYPE_LAST_COLOR_INT)) {
-        window.navigationBarColor = a.data
+    val tv = TypedValue()
+    theme.resolveAttribute(android.R.attr.colorBackground, tv, true)
+    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && tv.isColorType)
+        || (tv.type >= TypedValue.TYPE_FIRST_COLOR_INT && tv.type <= TypedValue.TYPE_LAST_COLOR_INT)) {
+        window.navigationBarColor = tv.data
     }
 }
 

--- a/app/src/main/java/ani/dantotsu/media/anime/AnimeWatchFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/anime/AnimeWatchFragment.kt
@@ -559,6 +559,8 @@ class AnimeWatchFragment : Fragment() {
         super.onResume()
         binding.mediaInfoProgressBar.visibility = progress
         binding.animeSourceRecycler.layoutManager?.onRestoreInstanceState(state)
+
+        requireActivity().setNavigationTheme()
     }
 
     override fun onPause() {

--- a/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/manga/MangaReadFragment.kt
@@ -601,6 +601,7 @@ open class MangaReadFragment : Fragment(), ScanlatorSelectionListener {
         super.onResume()
         binding.mediaInfoProgressBar.visibility = progress
         binding.animeSourceRecycler.layoutManager?.onRestoreInstanceState(state)
+
         requireActivity().setNavigationTheme()
     }
 

--- a/app/src/main/java/ani/dantotsu/themes/ThemeManager.kt
+++ b/app/src/main/java/ani/dantotsu/themes/ThemeManager.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.os.Build
 import android.view.Window
 import android.view.WindowManager
 import ani.dantotsu.R
@@ -54,7 +55,10 @@ class ThemeManager(private val context: Activity) {
         }
 
         val window = context.window
-        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            @Suppress("DEPRECATION")
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+        }
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
         window.statusBarColor = 0x00000000
         context.setTheme(themeToApply)
@@ -137,7 +141,7 @@ class ThemeManager(private val context: Activity) {
 
             companion object {
                 fun fromString(value: String): Theme {
-                    return values().find { it.theme == value } ?: PURPLE
+                    return entries.find { it.theme == value } ?: PURPLE
                 }
             }
         }


### PR DESCRIPTION
This one is pretty straightforward. Sets the navbar themes whereever activities are initialized. Also fixes setting it on both the manga AND anime chapter / episode lists, while leaving the main view with a transparent one.