### PR TITLE
feat: add an option to revert bar hide

### DIFF
--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -149,7 +149,7 @@ fun initActivity(a: Activity) {
         if (navBarHeight == 0) {
             ViewCompat.getRootWindowInsets(window.decorView.findViewById(android.R.id.content))
                 ?.apply {
-                    navBarHeight = this.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
+                    navBarHeight = this.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
                 }
         }
         WindowInsetsControllerCompat(window, window.decorView).hide(WindowInsetsCompat.Type.statusBars())
@@ -165,9 +165,8 @@ fun initActivity(a: Activity) {
             val windowInsets =
                 ViewCompat.getRootWindowInsets(window.decorView.findViewById(android.R.id.content))
             if (windowInsets != null) {
-                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-                statusBarHeight = insets.top
-                navBarHeight = insets.bottom
+                statusBarHeight = windowInsets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+                navBarHeight = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
             }
         }
     if (a !is MainActivity) a.setNavigationTheme()
@@ -179,6 +178,23 @@ fun Activity.hideSystemBars() {
             WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         controller.hide(WindowInsetsCompat.Type.systemBars())
     }
+}
+
+fun Activity.hideSystemBarsExtendView() {
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    hideSystemBars()
+}
+
+fun Activity.showSystemBars() {
+    WindowInsetsControllerCompat(window, window.decorView).let { controller ->
+        controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+        controller.show(WindowInsetsCompat.Type.systemBars())
+    }
+}
+
+fun Activity.showSystemBarsRetractView() {
+    WindowCompat.setDecorFitsSystemWindows(window, true)
+    showSystemBars()
 }
 
 fun Activity.setNavigationTheme() {

--- a/app/src/main/java/ani/dantotsu/MainActivity.kt
+++ b/app/src/main/java/ani/dantotsu/MainActivity.kt
@@ -358,9 +358,6 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         initActivity(this)
-        binding.includedNavbar.navbarContainer.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-            bottomMargin = navBarHeight
-        }
         window.navigationBarColor = getColor(android.R.color.transparent)
     }
 

--- a/app/src/main/java/ani/dantotsu/media/manga/mangareader/MangaReaderActivity.kt
+++ b/app/src/main/java/ani/dantotsu/media/manga/mangareader/MangaReaderActivity.kt
@@ -121,7 +121,7 @@ class MangaReaderActivity : AppCompatActivity() {
         }
     }
 
-    private fun hideBars() {
+    private fun hideSystemBars() {
         if (PrefManager.getVal<Boolean>(PrefName.ShowSystemBars))
             showSystemBarsRetractView()
         else
@@ -155,7 +155,7 @@ class MangaReaderActivity : AppCompatActivity() {
 
         controllerDuration = (PrefManager.getVal<Float>(PrefName.AnimationSpeed) * 200).toLong()
 
-        hideBars()
+        hideSystemBars()
 
         var pageSliderTimer = Timer()
         fun pageSliderHide() {
@@ -397,7 +397,7 @@ class MangaReaderActivity : AppCompatActivity() {
     fun applySettings() {
 
         saveReaderSettings("${media.id}_current_settings", defaultSettings)
-        hideBars()
+        hideSystemBars()
 
         //true colors
         SubsamplingScaleImageView.setPreferredBitmapConfig(
@@ -781,7 +781,7 @@ class MangaReaderActivity : AppCompatActivity() {
             }
 
             if (!PrefManager.getVal<Boolean>(PrefName.ShowSystemBars)) {
-                hideBars()
+                hideSystemBars()
                 checkNotch()
             }
             //horizontal scrollbar
@@ -907,7 +907,7 @@ class MangaReaderActivity : AppCompatActivity() {
                         dialog.dismiss()
                         runnable.run()
                     }
-                    .setOnCancelListener { hideBars() }
+                    .setOnCancelListener { hideSystemBars() }
                     .create()
                     .show()
             } else {

--- a/app/src/main/java/ani/dantotsu/media/manga/mangareader/MangaReaderActivity.kt
+++ b/app/src/main/java/ani/dantotsu/media/manga/mangareader/MangaReaderActivity.kt
@@ -122,7 +122,10 @@ class MangaReaderActivity : AppCompatActivity() {
     }
 
     private fun hideBars() {
-        if (!PrefManager.getVal<Boolean>(PrefName.ShowSystemBars)) hideSystemBars()
+        if (PrefManager.getVal<Boolean>(PrefName.ShowSystemBars))
+            showSystemBarsRetractView()
+        else
+            hideSystemBarsExtendView()
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Hiding the bars seems to work great, but things get a little awkward when they aren't hidden or get hidden later. The two most notable issues this is meant to address are the chapter names getting jammed behind the status bar and the app's nav bar falling behind the system nav bar while there is a giant gap at the top.

<details>
<summary>Bars shown</summary>

![Screenshot_20240313_082305_Dantotsu ](https://github.com/rebelonion/Dantotsu/assets/1173913/8000c7ac-c260-4019-9ff6-0c31f3a94620)
</details>

<details>
<summary>Bars hidden</summary>

![Screenshot_20240313_082408_Dantotsu ](https://github.com/rebelonion/Dantotsu/assets/1173913/dbc39c05-a9d4-465d-81b2-d33d999e3d29)
</details>
