### PR TITLE
fix: error when streams are empty

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/anime/SelectorDialogFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/anime/SelectorDialogFragment.kt
@@ -191,6 +191,12 @@ class SelectorDialogFragment : BottomSheetDialogFragment() {
                             }
                             binding.selectorProgressBar.visibility = View.GONE
                         }
+                        if (adapter.itemCount == 0) {
+                            snackString(getString(R.string.stream_selection_emoty))
+                            tryWith {
+                                dismiss()
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,6 +413,7 @@
     <string name="reset_auto_update">You can long click List Editor button to Reset Auto Update</string>
     <string name="autoplay_cancelled">Autoplay cancelled, no Interaction for more than 1 Hour.</string>
     <string name="auto_select_server_error">Couldn\'t auto select the server, Please try again!</string>
+    <string name="stream_selection_emoty">No streams available for content. Try another source.</string>
     <string name="logging_in_mal">Logging in MAL</string>
     <string name="getting_user_data">Getting User Data</string>
     <string name="no_next_episode">No next Episode Found!</string>


### PR DESCRIPTION
The current design simply presents an empty server list and leaves the user to click away. No action can be taken without leaving the dialog.