### PR TITLE
feat: delete item from context menu

### DIFF
--- a/app/src/main/java/ani/dantotsu/connections/anilist/AnilistQueries.kt
+++ b/app/src/main/java/ani/dantotsu/connections/anilist/AnilistQueries.kt
@@ -66,52 +66,6 @@ class AnilistQueries {
         return Media(fetchedMedia)
     }
 
-    fun mediaProfile(media: Media): Media {
-        val query =
-            """{Media(id:${media.id}){id mediaListEntry{id status progress private repeat customLists updatedAt startedAt{year month day}completedAt{year month day}}isFavourite idMal}}"""
-        runBlocking {
-            val anilist = async {
-                var response = executeQuery<Query.Media>(query, force = true, show = true)
-                if (response != null) {
-                    fun parse() {
-                        val fetchedMedia = response?.data?.media ?: return
-
-                        if (fetchedMedia.mediaListEntry != null) {
-                            fetchedMedia.mediaListEntry?.apply {
-                                media.userProgress = progress
-                                media.isListPrivate = private ?: false
-                                media.userListId = id
-                                media.userStatus = status?.toString()
-                                media.inCustomListsOf = customLists?.toMutableMap()
-                                media.userRepeat = repeat ?: 0
-                                media.userUpdatedAt = updatedAt?.toString()?.toLong()?.times(1000)
-                                media.userCompletedAt = completedAt ?: FuzzyDate()
-                                media.userStartedAt = startedAt ?: FuzzyDate()
-                            }
-                        } else {
-                            media.isListPrivate = false
-                            media.userStatus = null
-                            media.userListId = null
-                            media.userProgress = null
-                            media.userRepeat = 0
-                            media.userUpdatedAt = null
-                            media.userCompletedAt = FuzzyDate()
-                            media.userStartedAt = FuzzyDate()
-                        }
-                    }
-
-                    if (response.data?.media != null) parse()
-                    else {
-                        response = executeQuery(query, force = true, useToken = false)
-                        if (response?.data?.media != null) parse()
-                    }
-                }
-            }
-            awaitAll(anilist)
-        }
-        return media
-    }
-
     fun mediaDetails(media: Media): Media {
         media.cameFromContinue = false
 
@@ -338,6 +292,52 @@ class AnilistQueries {
                 }
             }
             awaitAll(anilist, mal)
+        }
+        return media
+    }
+
+    fun userMediaDetails(media: Media): Media {
+        val query =
+            """{Media(id:${media.id}){id mediaListEntry{id status progress private repeat customLists updatedAt startedAt{year month day}completedAt{year month day}}isFavourite idMal}}"""
+        runBlocking {
+            val anilist = async {
+                var response = executeQuery<Query.Media>(query, force = true, show = true)
+                if (response != null) {
+                    fun parse() {
+                        val fetchedMedia = response?.data?.media ?: return
+
+                        if (fetchedMedia.mediaListEntry != null) {
+                            fetchedMedia.mediaListEntry?.apply {
+                                media.userProgress = progress
+                                media.isListPrivate = private ?: false
+                                media.userListId = id
+                                media.userStatus = status?.toString()
+                                media.inCustomListsOf = customLists?.toMutableMap()
+                                media.userRepeat = repeat ?: 0
+                                media.userUpdatedAt = updatedAt?.toString()?.toLong()?.times(1000)
+                                media.userCompletedAt = completedAt ?: FuzzyDate()
+                                media.userStartedAt = startedAt ?: FuzzyDate()
+                            }
+                        } else {
+                            media.isListPrivate = false
+                            media.userStatus = null
+                            media.userListId = null
+                            media.userProgress = null
+                            media.userRepeat = 0
+                            media.userUpdatedAt = null
+                            media.userCompletedAt = FuzzyDate()
+                            media.userStartedAt = FuzzyDate()
+                        }
+                    }
+
+                    if (response.data?.media != null) parse()
+                    else {
+                        response = executeQuery(query, force = true, useToken = false)
+                        if (response?.data?.media != null) parse()
+                    }
+                }
+            }
+            awaitAll(anilist)
         }
         return media
     }

--- a/app/src/main/java/ani/dantotsu/media/MediaListDialogFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/MediaListDialogFragment.kt
@@ -254,20 +254,28 @@ class MediaListDialogFragment : BottomSheetDialogFragment() {
                 }
 
                 binding.mediaListDelete.setOnClickListener {
-                    val id = media!!.userListId
-                    if (id != null) {
-                        scope.launch {
-                            withContext(Dispatchers.IO) {
-                                Anilist.mutation.deleteList(id)
+                    var id = media!!.userListId
+                    scope.launch {
+                        withContext(Dispatchers.IO) {
+                            if (id != null) {
+                                Anilist.mutation.deleteList(id!!)
                                 MAL.query.deleteList(media?.anime != null, media?.idMAL)
+                            } else {
+                                val profile = Anilist.query.mediaProfile(media!!)
+                                profile.userListId?.let { listId ->
+                                    id = listId
+                                    Anilist.mutation.deleteList(listId)
+                                    MAL.query.deleteList(media?.anime != null, media?.idMAL)
+                                }
                             }
-                            Refresh.all()
-                            snackString(getString(R.string.deleted_from_list))
-                            dismissAllowingStateLoss()
                         }
+                    }
+                    if (id != null) {
+                        Refresh.all()
+                        snackString(getString(R.string.deleted_from_list))
+                        dismissAllowingStateLoss()
                     } else {
                         snackString(getString(R.string.no_list_id))
-                        Refresh.all()
                     }
                 }
             }

--- a/app/src/main/java/ani/dantotsu/media/MediaListDialogFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/MediaListDialogFragment.kt
@@ -261,7 +261,7 @@ class MediaListDialogFragment : BottomSheetDialogFragment() {
                                 Anilist.mutation.deleteList(id!!)
                                 MAL.query.deleteList(media?.anime != null, media?.idMAL)
                             } else {
-                                val profile = Anilist.query.mediaProfile(media!!)
+                                val profile = Anilist.query.userMediaDetails(media!!)
                                 profile.userListId?.let { listId ->
                                     id = listId
                                     Anilist.mutation.deleteList(listId)

--- a/app/src/main/java/ani/dantotsu/media/MediaListDialogSmallFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/MediaListDialogSmallFragment.kt
@@ -73,7 +73,7 @@ class MediaListDialogSmallFragment : BottomSheetDialogFragment() {
                             return@withContext
                         }
                     } else {
-                        val profile = Anilist.query.mediaProfile(media)
+                        val profile = Anilist.query.userMediaDetails(media)
                         profile.userListId?.let { listId ->
                             id = listId
                             Anilist.mutation.deleteList(listId)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -433,7 +433,7 @@
     <string name="episode_not_found">Couldn\'t find episode : %1$s</string>
     <string name="list_updated">List Updated</string>
     <string name="deleted_from_list">Deleted from List</string>
-    <string name="no_list_id">No List ID found, reloading…</string>
+    <string name="no_list_id">No List ID found…</string>
     <string name="checking_for_update">Checking for Update</string>
     <string name="dont_show_again">Don\'t show again for version %1$s</string>
     <string name="no_update_found">No Update Found</string>


### PR DESCRIPTION
This was split off from #245 because it's useful with or without the other feature. 

When you add an item to a list on the home screen, you can long click to open the list editor. Unfortunately, the delete button is tied to an id that is only available after opening the item and using the list editor in that view. 

This adds fallback for retrieving an id that will allow deleting from the home screen. The query is limited to the media list entry, which may be useful for something else in the future.