### PR TITLE
Add transparency options to subtitle

### DIFF
--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -270,6 +270,32 @@ fun Activity.setNavigationTheme() {
     }
 }
 
+fun Activity.reloadActivity() {
+    Refresh.all()
+    finish()
+    startActivity(Intent(this, this::class.java))
+    initActivity(this)
+}
+
+fun Context.restartApp(view: View) {
+    val mainIntent = Intent.makeRestartActivityTask(
+        packageManager.getLaunchIntentForPackage(this.packageName)!!.component
+    )
+    val component = ComponentName(this@restartApp.packageName, this@restartApp::class.qualifiedName!!)
+    Snackbar.make(view, R.string.restart_app, Snackbar.LENGTH_INDEFINITE).apply {
+        setAction(R.string.do_it) {
+            this.dismiss()
+            try {
+                startActivity(Intent().setComponent(component))
+            } catch (anything: Exception) {
+                startActivity(mainIntent)
+            }
+            Runtime.getRuntime().exit(0)
+        }
+        show()
+    }
+}
+
 open class BottomSheetDialogFragment : BottomSheetDialogFragment() {
     override fun onStart() {
         super.onStart()

--- a/app/src/main/java/ani/dantotsu/media/anime/ExoplayerView.kt
+++ b/app/src/main/java/ani/dantotsu/media/anime/ExoplayerView.kt
@@ -483,7 +483,7 @@ class ExoplayerView : AppCompatActivity(), Player.Listener, SessionAvailabilityL
 
 
         playerView.subtitleView?.alpha = when (PrefManager.getVal<Boolean>(PrefName.Subtitles)) {
-            true -> 1f
+            true -> PrefManager.getVal(PrefName.SubAlpha)
             false -> 0f
         }
         val fontSize = PrefManager.getVal<Int>(PrefName.FontSize).toFloat()

--- a/app/src/main/java/ani/dantotsu/others/Xpandable.kt
+++ b/app/src/main/java/ani/dantotsu/others/Xpandable.kt
@@ -13,6 +13,7 @@ class Xpandable @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
 ) : LinearLayout(context, attrs) {
     var expanded: Boolean = false
+    private var listener: OnChangeListener? = null
 
     init {
         context.withStyledAttributes(attrs, R.styleable.Xpandable) {
@@ -37,7 +38,6 @@ class Xpandable @JvmOverloads constructor(
         super.onAttachedToWindow()
     }
 
-
     private fun hideAll() {
         children.forEach {
             if (it != getChildAt(0)) {
@@ -48,8 +48,10 @@ class Xpandable @JvmOverloads constructor(
                     it.visibility = GONE
                 }, 300)
             }
-
         }
+        postDelayed({
+            listener?.onRetract()
+        }, 300)
     }
 
     private fun showAll() {
@@ -61,6 +63,19 @@ class Xpandable @JvmOverloads constructor(
                 ObjectAnimator.ofFloat(it, "alpha", 0f, 1f).setDuration(200).start()
             }
         }
+        postDelayed({
+            listener?.onExpand()
+        }, 300)
+    }
+
+    @Suppress("unused")
+    fun setOnChangeListener(listener: OnChangeListener) {
+        this.listener = listener
+    }
+
+    interface OnChangeListener {
+        fun onExpand()
+        fun onRetract()
     }
 
 }

--- a/app/src/main/java/ani/dantotsu/settings/PlayerSettingsActivity.kt
+++ b/app/src/main/java/ani/dantotsu/settings/PlayerSettingsActivity.kt
@@ -1,14 +1,17 @@
 package ani.dantotsu.settings
 
 import android.app.AlertDialog
-import android.content.Intent
+import android.content.res.Resources
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.addTextChangedListener
 import ani.dantotsu.R
@@ -16,16 +19,16 @@ import ani.dantotsu.databinding.ActivityPlayerSettingsBinding
 import ani.dantotsu.initActivity
 import ani.dantotsu.media.Media
 import ani.dantotsu.navBarHeight
+import ani.dantotsu.others.Xpandable
 import ani.dantotsu.others.getSerialized
 import ani.dantotsu.parsers.Subtitle
-import ani.dantotsu.restartApp
 import ani.dantotsu.settings.saving.PrefManager
 import ani.dantotsu.settings.saving.PrefName
 import ani.dantotsu.snackString
 import ani.dantotsu.statusBarHeight
 import ani.dantotsu.themes.ThemeManager
 import ani.dantotsu.toast
-import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.slider.Slider.OnChangeListener
 import kotlin.math.roundToInt
 
 
@@ -36,6 +39,9 @@ class PlayerSettingsActivity : AppCompatActivity() {
     var media: Media? = null
     var subtitle: Subtitle? = null
 
+    private val Int.toSP get() = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_SP, this.toFloat(), Resources.getSystem().displayMetrics
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -274,47 +280,33 @@ class PlayerSettingsActivity : AppCompatActivity() {
             dialog.window?.setDimAmount(0.8f)
         }
 
-        fun toggleButton(button: android.widget.Button, toggle: Boolean) {
-            button.isClickable = toggle
-            button.alpha = when (toggle) {
-                true -> 1f
-                false -> 0.5f
-            }
-        }
-
         fun toggleSubOptions(isChecked: Boolean) {
-            toggleButton(binding.videoSubColorPrimary, isChecked)
-            toggleButton(binding.videoSubColorSecondary, isChecked)
-            toggleButton(binding.videoSubOutline, isChecked)
-            toggleButton(binding.videoSubFont, isChecked)
-            binding.subtitleFontSizeCard.isEnabled = isChecked
-            binding.subtitleFontSizeCard.isClickable = isChecked
-            binding.subtitleFontSizeCard.alpha = when (isChecked) {
-                true -> 1f
-                false -> 0.5f
-            }
-            binding.subtitleFontSize.isEnabled = isChecked
-            binding.subtitleFontSize.isClickable = isChecked
-            binding.subtitleFontSize.alpha = when (isChecked) {
-                true -> 1f
-                false -> 0.5f
-            }
-            ActivityPlayerSettingsBinding.bind(binding.root).subtitleFontSizeText.isEnabled =
-                isChecked
-            ActivityPlayerSettingsBinding.bind(binding.root).subtitleFontSizeText.isClickable =
-                isChecked
-            ActivityPlayerSettingsBinding.bind(binding.root).subtitleFontSizeText.alpha =
-                when (isChecked) {
+            arrayOf(
+                binding.videoSubColorPrimary,
+                binding.videoSubColorSecondary,
+                binding.videoSubOutline,
+                binding.videoSubColorBackground,
+                binding.videoSubAlphaButton,
+                binding.videoSubColorWindow,
+                binding.videoSubFont,
+                binding.videoSubAlpha,
+                binding.subtitleFontSizeText,
+                binding.subtitleFontSize
+            ).forEach {
+                it.isEnabled = isChecked
+                it.isClickable = isChecked
+                it.alpha = when (isChecked) {
                     true -> 1f
                     false -> 0.5f
                 }
+            }
         }
         binding.subSwitch.isChecked = PrefManager.getVal(PrefName.Subtitles)
         binding.subSwitch.setOnCheckedChangeListener { _, isChecked ->
             PrefManager.setVal(PrefName.Subtitles, isChecked)
             toggleSubOptions(isChecked)
-            restartApp(binding.root)
         }
+        toggleSubOptions(binding.subSwitch.isChecked)
         val colorsPrimary =
             arrayOf(
                 "Black",
@@ -338,6 +330,7 @@ class PlayerSettingsActivity : AppCompatActivity() {
             ) { dialog, count ->
                 PrefManager.setVal(PrefName.PrimaryColor, count)
                 dialog.dismiss()
+                updateSubPreview()
             }.show()
             dialog.window?.setDimAmount(0.8f)
         }
@@ -364,6 +357,7 @@ class PlayerSettingsActivity : AppCompatActivity() {
             ) { dialog, count ->
                 PrefManager.setVal(PrefName.SecondaryColor, count)
                 dialog.dismiss()
+                updateSubPreview()
             }.show()
             dialog.window?.setDimAmount(0.8f)
         }
@@ -377,6 +371,7 @@ class PlayerSettingsActivity : AppCompatActivity() {
             ) { dialog, count ->
                 PrefManager.setVal(PrefName.Outline, count)
                 dialog.dismiss()
+                updateSubPreview()
             }.show()
             dialog.window?.setDimAmount(0.8f)
         }
@@ -403,6 +398,7 @@ class PlayerSettingsActivity : AppCompatActivity() {
             ) { dialog, count ->
                 PrefManager.setVal(PrefName.SubBackground, count)
                 dialog.dismiss()
+                updateSubPreview()
             }.show()
             dialog.window?.setDimAmount(0.8f)
         }
@@ -430,9 +426,19 @@ class PlayerSettingsActivity : AppCompatActivity() {
             ) { dialog, count ->
                 PrefManager.setVal(PrefName.SubWindow, count)
                 dialog.dismiss()
+                updateSubPreview()
             }.show()
             dialog.window?.setDimAmount(0.8f)
         }
+
+        binding.videoSubAlpha.value = PrefManager.getVal(PrefName.SubAlpha)
+        binding.videoSubAlpha.addOnChangeListener(OnChangeListener { _, value, fromUser ->
+            if (fromUser) {
+                PrefManager.setVal(PrefName.SubAlpha, value)
+                updateSubPreview()
+            }
+        })
+
         val fonts = arrayOf(
             "Poppins Semi Bold",
             "Poppins Bold",
@@ -451,6 +457,7 @@ class PlayerSettingsActivity : AppCompatActivity() {
             ) { dialog, count ->
                 PrefManager.setVal(PrefName.Font, count)
                 dialog.dismiss()
+                updateSubPreview()
             }.show()
             dialog.window?.setDimAmount(0.8f)
         }
@@ -465,8 +472,79 @@ class PlayerSettingsActivity : AppCompatActivity() {
             val size = binding.subtitleFontSize.text.toString().toIntOrNull()
             if (size != null) {
                 PrefManager.setVal(PrefName.FontSize, size)
+                updateSubPreview()
             }
         }
-        toggleSubOptions(PrefManager.getVal(PrefName.Subtitles))
+        binding.subtitleTest.setOnChangeListener(object: Xpandable.OnChangeListener {
+            override fun onExpand() {
+                updateSubPreview()
+            }
+            override fun onRetract() {}
+        })
+        updateSubPreview()
+    }
+
+    private fun updateSubPreview() {
+        binding.subtitleTestWindow.run {
+            alpha = PrefManager.getVal(PrefName.SubAlpha)
+            setBackgroundColor(when (PrefManager.getVal<Int>(PrefName.SubWindow)) {
+                0 -> Color.TRANSPARENT
+                1 -> Color.BLACK
+                2 -> Color.DKGRAY
+                3 -> Color.GRAY
+                4 -> Color.LTGRAY
+                5 -> Color.WHITE
+                6 -> Color.RED
+                7 -> Color.YELLOW
+                8 -> Color.GREEN
+                9 -> Color.CYAN
+                10 -> Color.BLUE
+                11 -> Color.MAGENTA
+                else -> Color.TRANSPARENT
+            })
+        }
+        binding.subtitleTestText.run {
+            textSize =  PrefManager.getVal<Int>(PrefName.FontSize).toSP
+            typeface = when (PrefManager.getVal<Int>(PrefName.Font)) {
+                0 -> ResourcesCompat.getFont(this.context, R.font.poppins_semi_bold)
+                1 -> ResourcesCompat.getFont(this.context, R.font.poppins_bold)
+                2 -> ResourcesCompat.getFont(this.context, R.font.poppins)
+                3 -> ResourcesCompat.getFont(this.context, R.font.poppins_thin)
+                4 -> ResourcesCompat.getFont(this.context, R.font.century_gothic_regular)
+                5 -> ResourcesCompat.getFont(this.context, R.font.levenim_mt_bold)
+                6 -> ResourcesCompat.getFont(this.context, R.font.blocky)
+                else -> ResourcesCompat.getFont(this.context, R.font.poppins_semi_bold)
+            }
+            setTextColor(when (PrefManager.getVal<Int>(PrefName.PrimaryColor)) {
+                0 -> Color.BLACK
+                1 -> Color.DKGRAY
+                2 -> Color.GRAY
+                3 -> Color.LTGRAY
+                4 -> Color.WHITE
+                5 -> Color.RED
+                6 -> Color.YELLOW
+                7 -> Color.GREEN
+                8 -> Color.CYAN
+                9 -> Color.BLUE
+                10 -> Color.MAGENTA
+                11 -> Color.TRANSPARENT
+                else -> Color.WHITE
+            })
+            setBackgroundColor(when (PrefManager.getVal<Int>(PrefName.SubBackground)) {
+                0 -> Color.TRANSPARENT
+                1 -> Color.BLACK
+                2 -> Color.DKGRAY
+                3 -> Color.GRAY
+                4 -> Color.LTGRAY
+                5 -> Color.WHITE
+                6 -> Color.RED
+                7 -> Color.YELLOW
+                8 -> Color.GREEN
+                9 -> Color.CYAN
+                10 -> Color.BLUE
+                11 -> Color.MAGENTA
+                else -> Color.TRANSPARENT
+            })
+        }
     }
 }

--- a/app/src/main/java/ani/dantotsu/settings/PlayerSettingsActivity.kt
+++ b/app/src/main/java/ani/dantotsu/settings/PlayerSettingsActivity.kt
@@ -18,6 +18,7 @@ import ani.dantotsu.media.Media
 import ani.dantotsu.navBarHeight
 import ani.dantotsu.others.getSerialized
 import ani.dantotsu.parsers.Subtitle
+import ani.dantotsu.restartApp
 import ani.dantotsu.settings.saving.PrefManager
 import ani.dantotsu.settings.saving.PrefName
 import ani.dantotsu.snackString
@@ -273,25 +274,6 @@ class PlayerSettingsActivity : AppCompatActivity() {
             dialog.window?.setDimAmount(0.8f)
         }
 
-        fun restartApp() {
-            Snackbar.make(
-                binding.root,
-                R.string.restart_app, Snackbar.LENGTH_SHORT
-            ).apply {
-                val mainIntent =
-                    Intent.makeRestartActivityTask(
-                        context.packageManager.getLaunchIntentForPackage(
-                            context.packageName
-                        )!!.component
-                    )
-                setAction("Do it!") {
-                    context.startActivity(mainIntent)
-                    Runtime.getRuntime().exit(0)
-                }
-                show()
-            }
-        }
-
         fun toggleButton(button: android.widget.Button, toggle: Boolean) {
             button.isClickable = toggle
             button.alpha = when (toggle) {
@@ -331,7 +313,7 @@ class PlayerSettingsActivity : AppCompatActivity() {
         binding.subSwitch.setOnCheckedChangeListener { _, isChecked ->
             PrefManager.setVal(PrefName.Subtitles, isChecked)
             toggleSubOptions(isChecked)
-            restartApp()
+            restartApp(binding.root)
         }
         val colorsPrimary =
             arrayOf(

--- a/app/src/main/java/ani/dantotsu/settings/SettingsActivity.kt
+++ b/app/src/main/java/ani/dantotsu/settings/SettingsActivity.kt
@@ -1,6 +1,5 @@
 package ani.dantotsu.settings
 
-import android.annotation.SuppressLint
 import android.app.AlarmManager
 import android.app.AlertDialog
 import android.content.Context
@@ -33,7 +32,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.offline.DownloadService
 import ani.dantotsu.BuildConfig
 import ani.dantotsu.R
-import ani.dantotsu.Refresh
 import ani.dantotsu.connections.anilist.Anilist
 import ani.dantotsu.connections.anilist.api.NotificationType
 import ani.dantotsu.connections.discord.Discord
@@ -66,6 +64,8 @@ import ani.dantotsu.openSettings
 import ani.dantotsu.others.AppUpdater
 import ani.dantotsu.others.CustomBottomDialog
 import ani.dantotsu.pop
+import ani.dantotsu.reloadActivity
+import ani.dantotsu.restartApp
 import ani.dantotsu.savePrefsToDownloads
 import ani.dantotsu.setSafeOnClickListener
 import ani.dantotsu.settings.saving.PrefManager
@@ -79,7 +79,6 @@ import ani.dantotsu.statusBarHeight
 import ani.dantotsu.themes.ThemeManager
 import ani.dantotsu.toast
 import ani.dantotsu.util.Logger
-import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputEditText
 import eltos.simpledialogfragment.SimpleDialog
 import eltos.simpledialogfragment.SimpleDialog.OnDialogResultListener.BUTTON_POSITIVE
@@ -144,7 +143,7 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
                                         return@passwordAlertDialog
                                     }
                                     if (PreferencePackager.unpack(decryptedJson))
-                                        restartApp()
+                                        restartApp(binding.root)
                                 } else {
                                     toast(getString(R.string.password_cannot_be_empty))
                                 }
@@ -152,7 +151,7 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
                         } else if (name.endsWith(".ani")) {
                             val decryptedJson = jsonString.toString(Charsets.UTF_8)
                             if (PreferencePackager.unpack(decryptedJson))
-                                restartApp()
+                                restartApp(binding.root)
                         } else {
                             toast(getString(R.string.unknown_file_type))
                         }
@@ -316,7 +315,7 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
             settingsUseMaterialYou.setOnCheckedChangeListener { _, isChecked ->
                 PrefManager.setVal(PrefName.UseMaterialYou, isChecked)
                 if (isChecked) settingsUseCustomTheme.isChecked = false
-                restartApp()
+                restartApp(binding.root)
             }
 
             settingsUseCustomTheme.isChecked =
@@ -327,20 +326,20 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
                     settingsUseMaterialYou.isChecked = false
                 }
 
-                restartApp()
+                restartApp(binding.root)
             }
 
             settingsUseSourceTheme.isChecked =
                 PrefManager.getVal(PrefName.UseSourceTheme)
             settingsUseSourceTheme.setOnCheckedChangeListener { _, isChecked ->
                 PrefManager.setVal(PrefName.UseSourceTheme, isChecked)
-                restartApp()
+                restartApp(binding.root)
             }
 
             settingsUseOLED.isChecked = PrefManager.getVal(PrefName.UseOLED)
             settingsUseOLED.setOnCheckedChangeListener { _, isChecked ->
                 PrefManager.setVal(PrefName.UseOLED, isChecked)
-                restartApp()
+                restartApp(binding.root)
             }
 
             val themeString: String = PrefManager.getVal(PrefName.Theme)
@@ -359,17 +358,15 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
                 PrefManager.setVal(PrefName.Theme, ThemeManager.Companion.Theme.entries[i].theme)
                 //ActivityHelper.shouldRefreshMainActivity = true
                 themeSwitcher.clearFocus()
-                restartApp()
-
+                restartApp(binding.root)
             }
-
 
             customTheme.setOnClickListener {
                 val originalColor: Int = PrefManager.getVal(PrefName.CustomThemeInt)
 
                 class CustomColorDialog : SimpleColorDialog() { //idk where to put it
                     override fun onPositiveButtonClick() {
-                        restartApp()
+                        restartApp(binding.root)
                         super.onPositiveButtonClick()
                     }
                 }
@@ -398,10 +395,7 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
                 previous = current
                 current.alpha = 1f
                 PrefManager.setVal(PrefName.DarkMode, mode)
-                Refresh.all()
-                finish()
-                startActivity(Intent(this@SettingsActivity, SettingsActivity::class.java))
-                initActivity(this@SettingsActivity)
+                reloadActivity()
             }
 
             settingsUiAuto.setOnClickListener {
@@ -688,7 +682,7 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
             settingsExtensionDns.setOnItemClickListener { _, _, i, _ ->
                 PrefManager.setVal(PrefName.DohProvider, i)
                 settingsExtensionDns.clearFocus()
-                restartApp()
+                restartApp(binding.root)
             }
 
             settingsDownloadInSd.isChecked = PrefManager.getVal(PrefName.SdDl)
@@ -968,7 +962,7 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
             settingsLogToFile.isChecked = PrefManager.getVal(PrefName.LogToFile)
             settingsLogToFile.setOnCheckedChangeListener { _, isChecked ->
                 PrefManager.setVal(PrefName.LogToFile, isChecked)
-                restartApp()
+                restartApp(binding.root)
             }
 
             settingsShareLog.setOnClickListener {
@@ -1048,25 +1042,6 @@ class SettingsActivity : AppCompatActivity(), SimpleDialog.OnDialogResultListene
             }
         }
         return true
-    }
-
-    private fun restartApp() {
-        Snackbar.make(
-            binding.root,
-            R.string.restart_app, Snackbar.LENGTH_SHORT
-        ).apply {
-            val mainIntent =
-                Intent.makeRestartActivityTask(
-                    context.packageManager.getLaunchIntentForPackage(
-                        context.packageName
-                    )!!.component
-                )
-            setAction(getString(R.string.do_it)) {
-                context.startActivity(mainIntent)
-                Runtime.getRuntime().exit(0)
-            }
-            show()
-        }
     }
 
     private fun passwordAlertDialog(isExporting: Boolean, callback: (CharArray?) -> Unit) {

--- a/app/src/main/java/ani/dantotsu/settings/UserInterfaceSettingsActivity.kt
+++ b/app/src/main/java/ani/dantotsu/settings/UserInterfaceSettingsActivity.kt
@@ -10,6 +10,7 @@ import ani.dantotsu.R
 import ani.dantotsu.databinding.ActivityUserInterfaceSettingsBinding
 import ani.dantotsu.initActivity
 import ani.dantotsu.navBarHeight
+import ani.dantotsu.restartApp
 import ani.dantotsu.settings.saving.PrefManager
 import ani.dantotsu.settings.saving.PrefName
 import ani.dantotsu.statusBarHeight
@@ -49,7 +50,7 @@ class UserInterfaceSettingsActivity : AppCompatActivity() {
                     }
                     setPositiveButton("Done") { _, _ ->
                         PrefManager.setVal(PrefName.HomeLayoutShow, set)
-                        restartApp()
+                        restartApp(binding.root)
                     }
                 }.show()
             dialog.window?.setDimAmount(0.8f)
@@ -58,24 +59,24 @@ class UserInterfaceSettingsActivity : AppCompatActivity() {
         binding.uiSettingsSmallView.isChecked = PrefManager.getVal(PrefName.SmallView)
         binding.uiSettingsSmallView.setOnCheckedChangeListener { _, isChecked ->
             PrefManager.setVal(PrefName.SmallView, isChecked)
-            restartApp()
+            restartApp(binding.root)
         }
 
         binding.uiSettingsImmersive.isChecked = PrefManager.getVal(PrefName.ImmersiveMode)
         binding.uiSettingsImmersive.setOnCheckedChangeListener { _, isChecked ->
             PrefManager.setVal(PrefName.ImmersiveMode, isChecked)
-            restartApp()
+            restartApp(binding.root)
         }
         binding.uiSettingsBannerAnimation.isChecked = PrefManager.getVal(PrefName.BannerAnimations)
         binding.uiSettingsBannerAnimation.setOnCheckedChangeListener { _, isChecked ->
             PrefManager.setVal(PrefName.BannerAnimations, isChecked)
-            restartApp()
+            restartApp(binding.root)
         }
 
         binding.uiSettingsLayoutAnimation.isChecked = PrefManager.getVal(PrefName.LayoutAnimations)
         binding.uiSettingsLayoutAnimation.setOnCheckedChangeListener { _, isChecked ->
             PrefManager.setVal(PrefName.LayoutAnimations, isChecked)
-            restartApp()
+            restartApp(binding.root)
         }
 
         val map = mapOf(
@@ -94,41 +95,22 @@ class UserInterfaceSettingsActivity : AppCompatActivity() {
             mapReverse[PrefManager.getVal(PrefName.AnimationSpeed)] ?: 1f
         binding.uiSettingsAnimationSpeed.addOnChangeListener { _, value, _ ->
             PrefManager.setVal(PrefName.AnimationSpeed, map[value] ?: 1f)
-            restartApp()
+            restartApp(binding.root)
         }
         binding.uiSettingsBlurBanners.isChecked = PrefManager.getVal(PrefName.BlurBanners)
         binding.uiSettingsBlurBanners.setOnCheckedChangeListener { _, isChecked ->
             PrefManager.setVal(PrefName.BlurBanners, isChecked)
-            restartApp()
+            restartApp(binding.root)
         }
         binding.uiSettingsBlurRadius.value = (PrefManager.getVal(PrefName.BlurRadius) as  Float)
         binding.uiSettingsBlurRadius.addOnChangeListener { _, value, _ ->
             PrefManager.setVal(PrefName.BlurRadius, value)
-            restartApp()
+            restartApp(binding.root)
         }
         binding.uiSettingsBlurSampling.value = (PrefManager.getVal(PrefName.BlurSampling) as Float)
         binding.uiSettingsBlurSampling.addOnChangeListener { _, value, _ ->
             PrefManager.setVal(PrefName.BlurSampling, value)
-            restartApp()
-        }
-    }
-
-    private fun restartApp() {
-        Snackbar.make(
-            binding.root,
-            R.string.restart_app, Snackbar.LENGTH_SHORT
-        ).apply {
-            val mainIntent =
-                Intent.makeRestartActivityTask(
-                    context.packageManager.getLaunchIntentForPackage(
-                        context.packageName
-                    )!!.component
-                )
-            setAction("Do it!") {
-                context.startActivity(mainIntent)
-                Runtime.getRuntime().exit(0)
-            }
-            show()
+            restartApp(binding.root)
         }
     }
 }

--- a/app/src/main/java/ani/dantotsu/settings/saving/Preferences.kt
+++ b/app/src/main/java/ani/dantotsu/settings/saving/Preferences.kt
@@ -86,6 +86,7 @@ enum class PrefName(val data: Pref) {  //TODO: Split this into multiple files
     Outline(Pref(Location.Player, Int::class, 0)),
     SubBackground(Pref(Location.Player, Int::class, 0)),
     SubWindow(Pref(Location.Player, Int::class, 0)),
+    SubAlpha(Pref(Location.Player, Float::class, 1f)),
     Font(Pref(Location.Player, Int::class, 0)),
     FontSize(Pref(Location.Player, Int::class, 20)),
     Locale(Pref(Location.Player, Int::class, 2)),

--- a/app/src/main/res/layout/activity_player_settings.xml
+++ b/app/src/main/res/layout/activity_player_settings.xml
@@ -166,6 +166,44 @@
                     app:drawableEndCompat="@drawable/ic_round_arrow_drop_down_24"
                     tools:ignore="TextContrastCheck" />
 
+                <ani.dantotsu.others.Xpandable
+                    android:id="@+id/subtitleTest"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="64dp"
+                        android:fontFamily="@font/poppins_bold"
+                        android:gravity="center_vertical"
+                        android:paddingHorizontal="32dp"
+                        android:text="@string/sub_text_example"
+                        android:textColor="?attr/colorSecondary"
+                        app:drawableEndCompat="@drawable/ic_round_arrow_drop_down_24"
+                        tools:ignore="TextContrastCheck" />
+
+                    <LinearLayout
+                        android:id="@+id/subtitleTestWindow"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/subtitleTestText"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingHorizontal="32dp"
+                            android:layout_gravity="center"
+                            android:gravity="center"
+                            android:text="@string/sub_text_example" />
+                    </LinearLayout>
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp" />
+                </ani.dantotsu.others.Xpandable>
+
                 <com.google.android.material.materialswitch.MaterialSwitch
                     android:id="@+id/subSwitch"
                     android:layout_width="match_parent"
@@ -291,6 +329,37 @@
                     android:paddingHorizontal="32dp"
                     android:text="@string/sub_window_color_info"
                     android:textSize="14sp" />
+
+                <Button
+                    android:id="@+id/videoSubAlphaButton"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="64dp"
+                    android:layout_marginBottom="8dp"
+                    android:fontFamily="@font/poppins_bold"
+                    android:insetTop="0dp"
+                    android:insetBottom="0dp"
+                    android:paddingHorizontal="32dp"
+                    android:text="@string/sub_alpha"
+                    android:textAlignment="viewStart"
+                    android:textAllCaps="false"
+                    android:textColor="@color/bg_opp"
+                    app:cornerRadius="0dp"
+                    app:icon="@drawable/ic_round_color_24"
+                    app:iconPadding="16dp"
+                    app:iconSize="24dp"
+                    android:clickable="false" />
+
+                <com.google.android.material.slider.Slider
+                    android:id="@+id/videoSubAlpha"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="32dp"
+                    android:valueFrom="0"
+                    android:valueTo="1"
+                    android:stepSize="0.1">
+
+                </com.google.android.material.slider.Slider>
 
                 <Button
                     android:id="@+id/videoSubFont"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,8 @@
     <string name="sub_window_color_select">Subtitle Window Color</string>
     <string name="sub_window_color_info">"The subtitle window is the part left and right from them. (where the background isn\'t)"</string>
     <string name="sub_color_info"><b>Note:</b> Changing above settings only affects Soft-Subtitles!</string>
+    <string name="sub_alpha">Subtitle Transparency</string>
+    <string name="sub_text_example">Example Subtitle</string>
     <string name="sub_font_select">Subtitle Font</string>
     <string name="subtitle_font_size">Subtitle Size</string>
 
@@ -344,14 +346,7 @@
     <string name="reload">Reload</string>
     <string name="share">Share</string>
     <string name="skip">Skip</string>
-    <string name="show_skip_time_stamp_button">Show Skip Time Stamp Button</string>
-    <string name="always_load_time_stamps">Always Load Time Stamps</string>
-    <string name="auto_hide_time_stamps">Auto Hide Time Stamps</string>string
-    <string name="hide_skip_button">Hide Skip Button</string>
-    <string name="timestamps">Time Stamps</string>
     <string name="other">Other</string>
-    <string name="auto_skip_op_ed">Auto Skip OP / ED</string>
-    <string name="requires_time_stamps_to_be_enabled">Requires Time Stamps to be Enabled</string>
     <string name="total_repeats">TOTAL REPEATS</string>
     <string name="custom_lists">Custom Lists</string>
     <string name="donate_desc">Want to support Dantotsu\'s Maintainer?\nConsider Donating</string>
@@ -428,6 +423,13 @@
     <string name="anilist_not_found">Seems like that wasn\'t found on Anilist.</string>
     <string name="disabled_auto_skip">Disabled Auto Skipping OP &amp; ED</string>
     <string name="auto_skip">Auto Skipping OP &amp; ED</string>
+    <string name="show_skip_time_stamp_button">Show Skip Time Stamp Button</string>
+    <string name="always_load_time_stamps">Always Load Time Stamps</string>
+    <string name="auto_hide_time_stamps">Auto Hide Time Stamps</string>string
+    <string name="timestamps">Time Stamps</string>
+    <string name="auto_skip_op_ed">Auto Skip OP / ED</string>
+    <string name="requires_time_stamps_to_be_enabled">Requires Time Stamps to be Enabled</string>
+    <string name="hide_skip_button">Make the skip time stamp button disappear after 5 seconds</string>
     <string name="copied_to_clipboard">Copied to Clipboard</string>
     <string name="first_episode">This is the 1st Episode!</string>
     <string name="reset_auto_update">You can long click List Editor button to Reset Auto Update</string>


### PR DESCRIPTION
This adds a transparency setting along with an early version of a subtitle preview. In addition, the backend to doing this updates the restart and refresh actions as shared calls, adds a state listener to the custom expandable view, and (somehow) inherited a few string fixes meant to be part of a previous PR.