### PR TITLE
feat: support exporting magnets

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/anime/ExoplayerView.kt
+++ b/app/src/main/java/ani/dantotsu/media/anime/ExoplayerView.kt
@@ -54,7 +54,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.math.MathUtils.clamp
 import androidx.core.view.isVisible
-import androidx.core.view.WindowCompat
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
 import androidx.media3.cast.CastPlayer


### PR DESCRIPTION
A very basic and somewhat cheesy way to offload torrent streaming to an app that supports it. Credit to kuukiyomi for the name of the app and providing the extras that can be targeted. Doesn't seem to return the intent well to actually support proper tracking updates, but it is a temporary solution.