### PR TITLE
fix: prefer caching the final version

### DIFF
--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -1272,7 +1272,7 @@ fun blurImage(imageView: ImageView, banner: String?) {
                 val url = PrefManager.getVal<String>(PrefName.ImageUrl).ifEmpty { banner }
                 Glide.with(context as Context)
                     .load(GlideUrl(url))
-                    .diskCacheStrategy(DiskCacheStrategy.ALL).override(400)
+                    .diskCacheStrategy(DiskCacheStrategy.RESOURCE).override(400)
                     .apply(RequestOptions.bitmapTransform(BlurTransformation(radius, sampling)))
                     .into(imageView)
             }


### PR DESCRIPTION
While caching the original and the final seems like an ideal way to reduce overhead, you cache an original copy of the image and the modified copy of the image to only ever load the modified copy. The size is set, meaning you are not reusing the original image. There is no reason to cache it.