### PR TITLE
fix: add padding to last item in recycler

### DIFF
--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -81,13 +81,16 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.children
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
+import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.viewpager2.widget.ViewPager2
 import ani.dantotsu.BuildConfig.APPLICATION_ID
 import ani.dantotsu.connections.anilist.Genre
@@ -268,6 +271,29 @@ fun Activity.setNavigationTheme() {
     ) {
         window.navigationBarColor = tv.data
     }
+}
+
+/**
+ * Sets clipToPadding false and sets the combined height of navigation bars as bottom padding.
+ *
+ * When nesting multiple scrolling views, only call this method on the highest level scrolling parent.
+ */
+fun ViewGroup.setBaseline(navBar: AnimatedBottomBar) {
+    navBar.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+    clipToPadding = false
+    setPadding(paddingLeft, paddingTop, paddingRight, navBarHeight + navBar.measuredHeight)
+}
+
+/**
+ * Sets clipToPadding false and sets the combined height of navigation bars as bottom padding.
+ *
+ * When nesting multiple scrolling views, only call this method on the highest level scrolling parent.
+ */
+fun ViewGroup.setBaseline(navBar: AnimatedBottomBar, overlayView: View) {
+    navBar.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+    overlayView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+    clipToPadding = false
+    setPadding(paddingLeft, paddingTop, paddingRight, navBarHeight + navBar.measuredHeight + overlayView.measuredHeight)
 }
 
 fun Activity.reloadActivity() {

--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -81,16 +81,13 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.core.view.children
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
-import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.RecyclerView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.viewpager2.widget.ViewPager2
 import ani.dantotsu.BuildConfig.APPLICATION_ID
 import ani.dantotsu.connections.anilist.Genre
@@ -276,7 +273,7 @@ fun Activity.setNavigationTheme() {
 /**
  * Sets clipToPadding false and sets the combined height of navigation bars as bottom padding.
  *
- * When nesting multiple scrolling views, only call this method on the highest level scrolling parent.
+ * When nesting multiple scrolling views, only call this method on the inner most scrolling view.
  */
 fun ViewGroup.setBaseline(navBar: AnimatedBottomBar) {
     navBar.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
@@ -287,7 +284,7 @@ fun ViewGroup.setBaseline(navBar: AnimatedBottomBar) {
 /**
  * Sets clipToPadding false and sets the combined height of navigation bars as bottom padding.
  *
- * When nesting multiple scrolling views, only call this method on the highest level scrolling parent.
+ * When nesting multiple scrolling views, only call this method on the inner most scrolling view.
  */
 fun ViewGroup.setBaseline(navBar: AnimatedBottomBar, overlayView: View) {
     navBar.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)

--- a/app/src/main/java/ani/dantotsu/media/MediaDetailsActivity.kt
+++ b/app/src/main/java/ani/dantotsu/media/MediaDetailsActivity.kt
@@ -127,9 +127,6 @@ class MediaDetailsActivity : AppCompatActivity(), AppBarLayout.OnOffsetChangedLi
             rightMargin = navBarRightMargin
             bottomMargin = navBarBottomMargin
         }
-        binding.commentMessageContainer.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-            bottomMargin = navBarRightMargin
-        }
         binding.mediaBanner.updateLayoutParams { height += statusBarHeight }
         binding.mediaBannerNoKen.updateLayoutParams { height += statusBarHeight }
         binding.mediaClose.updateLayoutParams<ViewGroup.MarginLayoutParams> { topMargin += statusBarHeight }

--- a/app/src/main/java/ani/dantotsu/media/comments/CommentsFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/comments/CommentsFragment.kt
@@ -75,7 +75,7 @@ class CommentsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         activity = requireActivity() as MediaDetailsActivity
 
-        binding.root.setBaseline(activity.navBar, activity.binding.commentInputLayout)
+        binding.commentsList.setBaseline(activity.navBar, activity.binding.commentInputLayout)
 
         //get the media id from the intent
         val mediaId = arguments?.getInt("mediaId") ?: -1
@@ -370,7 +370,7 @@ class CommentsFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         tag = null
-        binding.root.setBaseline(activity.navBar, activity.binding.commentInputLayout)
+        binding.commentsList.setBaseline(activity.navBar, activity.binding.commentInputLayout)
         section.groups.forEach {
             if (it is CommentItem && it.containsGif()) {
                 it.notifyChanged()

--- a/app/src/main/java/ani/dantotsu/media/comments/CommentsFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/comments/CommentsFragment.kt
@@ -28,6 +28,7 @@ import ani.dantotsu.connections.comments.CommentsAPI
 import ani.dantotsu.databinding.FragmentCommentsBinding
 import ani.dantotsu.loadImage
 import ani.dantotsu.media.MediaDetailsActivity
+import ani.dantotsu.setBaseline
 import ani.dantotsu.settings.saving.PrefManager
 import ani.dantotsu.settings.saving.PrefName
 import ani.dantotsu.snackString
@@ -73,6 +74,9 @@ class CommentsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         activity = requireActivity() as MediaDetailsActivity
+
+        binding.root.setBaseline(activity.navBar, activity.binding.commentInputLayout)
+
         //get the media id from the intent
         val mediaId = arguments?.getInt("mediaId") ?: -1
         mediaName = arguments?.getString("mediaName") ?: "unknown"
@@ -366,6 +370,7 @@ class CommentsFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         tag = null
+        binding.root.setBaseline(activity.navBar, activity.binding.commentInputLayout)
         section.groups.forEach {
             if (it is CommentItem && it.containsGif()) {
                 it.notifyChanged()

--- a/app/src/main/java/ani/dantotsu/profile/ProfileActivity.kt
+++ b/app/src/main/java/ani/dantotsu/profile/ProfileActivity.kt
@@ -46,7 +46,7 @@ import kotlin.math.abs
 class ProfileActivity : AppCompatActivity(), AppBarLayout.OnOffsetChangedListener {
     lateinit var binding: ActivityProfileBinding
     private var selected: Int = 0
-    private lateinit var navBar: AnimatedBottomBar
+    lateinit var navBar: AnimatedBottomBar
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/ani/dantotsu/profile/ProfileFragment.kt
+++ b/app/src/main/java/ani/dantotsu/profile/ProfileFragment.kt
@@ -30,6 +30,7 @@ import ani.dantotsu.media.CharacterAdapter
 import ani.dantotsu.media.Media
 import ani.dantotsu.media.MediaAdaptor
 import ani.dantotsu.media.user.ListActivity
+import ani.dantotsu.setBaseline
 import ani.dantotsu.setSlideIn
 import ani.dantotsu.setSlideUp
 import ani.dantotsu.util.AniMarkdown.Companion.getFullAniHTML
@@ -58,6 +59,8 @@ class ProfileFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         activity = requireActivity() as ProfileActivity
+
+        binding.root.setBaseline(activity.navBar)
 
         user = arguments?.getSerializableCompat<Query.UserProfile>("user") as Query.UserProfile
         viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
@@ -144,6 +147,7 @@ class ProfileFragment : Fragment() {
         super.onResume()
         if (this::binding.isInitialized) {
             binding.root.requestLayout()
+            binding.root.setBaseline(activity.navBar)
         }
     }
 

--- a/app/src/main/java/ani/dantotsu/profile/StatsFragment.kt
+++ b/app/src/main/java/ani/dantotsu/profile/StatsFragment.kt
@@ -17,6 +17,7 @@ import ani.dantotsu.profile.ChartBuilder.Companion.ChartPacket
 import ani.dantotsu.profile.ChartBuilder.Companion.ChartType
 import ani.dantotsu.profile.ChartBuilder.Companion.MediaType
 import ani.dantotsu.profile.ChartBuilder.Companion.StatType
+import ani.dantotsu.setBaseline
 import ani.dantotsu.statusBarHeight
 import com.github.aachartmodel.aainfographics.aachartcreator.AAChartType
 import com.xwray.groupie.GroupieAdapter
@@ -49,7 +50,10 @@ class StatsFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         activity = requireActivity() as ProfileActivity
+
         user = arguments?.getSerializableCompat<Query.UserProfile>("user") as Query.UserProfile
+
+        binding.statisticList.setBaseline(activity.navBar)
 
         binding.statisticList.adapter = adapter
         binding.statisticList.recycledViewPool.setMaxRecycledViews(0, 0)
@@ -114,6 +118,7 @@ class StatsFragment :
         super.onResume()
         if (this::binding.isInitialized) {
             binding.statisticList.visibility = View.VISIBLE
+            binding.statisticList.setBaseline(activity.navBar)
             binding.root.requestLayout()
             if (!loadedFirstTime) {
                 activity.lifecycleScope.launch {

--- a/app/src/main/java/ani/dantotsu/profile/activity/FeedFragment.kt
+++ b/app/src/main/java/ani/dantotsu/profile/activity/FeedFragment.kt
@@ -50,7 +50,7 @@ class FeedFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         activity = requireActivity()
 
-        binding.feedSwipeRefresh.setBaseline((activity as ProfileActivity).navBar)
+        binding.listRecyclerView.setBaseline((activity as ProfileActivity).navBar)
 
         binding.listRecyclerView.adapter = adapter
         binding.listRecyclerView.layoutManager =
@@ -67,7 +67,7 @@ class FeedFragment : Fragment() {
         super.onResume()
         if (this::binding.isInitialized) {
             binding.root.requestLayout()
-            binding.feedSwipeRefresh.setBaseline((activity as ProfileActivity).navBar)
+            binding.listRecyclerView.setBaseline((activity as ProfileActivity).navBar)
             if (!loadedFirstTime) {
                 activity.lifecycleScope.launch(Dispatchers.IO) {
                     val nulledId = if (activityId == -1) null else activityId

--- a/app/src/main/java/ani/dantotsu/profile/activity/FeedFragment.kt
+++ b/app/src/main/java/ani/dantotsu/profile/activity/FeedFragment.kt
@@ -18,6 +18,7 @@ import ani.dantotsu.connections.anilist.api.Activity
 import ani.dantotsu.databinding.FragmentFeedBinding
 import ani.dantotsu.media.MediaDetailsActivity
 import ani.dantotsu.profile.ProfileActivity
+import ani.dantotsu.setBaseline
 import ani.dantotsu.snackString
 import ani.dantotsu.util.Logger
 import com.xwray.groupie.GroupieAdapter
@@ -48,6 +49,9 @@ class FeedFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         activity = requireActivity()
+
+        binding.feedSwipeRefresh.setBaseline((activity as ProfileActivity).navBar)
+
         binding.listRecyclerView.adapter = adapter
         binding.listRecyclerView.layoutManager =
             LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
@@ -63,6 +67,7 @@ class FeedFragment : Fragment() {
         super.onResume()
         if (this::binding.isInitialized) {
             binding.root.requestLayout()
+            binding.feedSwipeRefresh.setBaseline((activity as ProfileActivity).navBar)
             if (!loadedFirstTime) {
                 activity.lifecycleScope.launch(Dispatchers.IO) {
                     val nulledId = if (activityId == -1) null else activityId

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -270,7 +270,6 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginBottom="64dp"
         android:orientation="vertical"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 

--- a/app/src/main/res/layout/fragment_comments.xml
+++ b/app/src/main/res/layout/fragment_comments.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/commentsLayout"
@@ -12,7 +13,6 @@
         android:id="@+id/commentsRefresh"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="122dp"
         android:clipChildren="false"
         android:clipToPadding="false">
 

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:scrollbars="none"
     android:layout_width="match_parent"


### PR DESCRIPTION
@sneazy-ibo @aayush2622 Gather round and let me tell you a story....

 `WindowCompat.setDecorFitsSystemWindows(window, false)` disables the limits placed on a window by the status bar and system navigation. It's set in the app to deal with the status bar, but then all of the views are compensating in code for the navigation bar that is still being shown. This leaves you constantly accounting for the system navigation when it's shown.

The AnimatedBottomBar is a library that draws its own view. If you set the size of it, it will pretty much ignore that and draw the same size as it would have from top to bottom, either being cut off or leaving a gap. If the size is taller than the view it draws, there will be a transparent gap at the bottom. So if you can't set the height, how do you avoid overlapping it? You can **measure it**.

As is, the code contains margins and padding and more margins and more padding across multiple views trying to prevent the AnimatedBottomBar from overlapping the bottom of scrolling views. The funny thing is that Android **already knows** about this issue, which is why `clipToPadding`, which tells a scrolling view to always maintain the padding, can be set to `false`. Setting it to false tells it to only apply the padding once there are no more items to display.

Now, as for this PR:

This change adds a utility method for the three main types of scrolling views used in the app. It sets the clipToPadding false (to allow only padding the very end) and then measures the stuff that will overlap it and sets that as the padding. No more guessing and no more trying to find a number that fits one view and doesn't break another.