### PR TITLE
feat: add watch title search button

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/MediaInfoFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/MediaInfoFragment.kt
@@ -35,6 +35,7 @@ import ani.dantotsu.databinding.ItemChipBinding
 import ani.dantotsu.databinding.ItemQuelsBinding
 import ani.dantotsu.databinding.ItemTitleChipgroupBinding
 import ani.dantotsu.databinding.ItemTitleRecyclerBinding
+import ani.dantotsu.databinding.ItemTitleSearchBinding
 import ani.dantotsu.databinding.ItemTitleTextBinding
 import ani.dantotsu.databinding.ItemTitleTrailerBinding
 import ani.dantotsu.loadImage
@@ -90,7 +91,6 @@ class MediaInfoFragment : Fragment() {
         model.getMedia().observe(viewLifecycleOwner) { media ->
             if (media != null && !loaded) {
                 loaded = true
-
 
                 binding.mediaInfoProgressBar.visibility = View.GONE
                 binding.mediaInfoContainer.visibility = View.VISIBLE
@@ -438,113 +438,138 @@ class MediaInfoFragment : Fragment() {
 
                 if (!media.relations.isNullOrEmpty() && !offline) {
                     if (media.sequel != null || media.prequel != null) {
-                        val bind = ItemQuelsBinding.inflate(
+                        ItemQuelsBinding.inflate(
                             LayoutInflater.from(context),
                             parent,
                             false
-                        )
+                        ).apply {
 
-                        if (media.sequel != null) {
-                            bind.mediaInfoSequel.visibility = View.VISIBLE
-                            bind.mediaInfoSequelImage.loadImage(
-                                media.sequel!!.banner ?: media.sequel!!.cover
-                            )
-                            bind.mediaInfoSequel.setSafeOnClickListener {
-                                ContextCompat.startActivity(
-                                    requireContext(),
-                                    Intent(
-                                        requireContext(),
-                                        MediaDetailsActivity::class.java
-                                    ).putExtra(
-                                        "media",
-                                        media.sequel as Serializable
-                                    ), null
+                            if (media.sequel != null) {
+                                mediaInfoSequel.visibility = View.VISIBLE
+                                mediaInfoSequelImage.loadImage(
+                                    media.sequel!!.banner ?: media.sequel!!.cover
                                 )
-                            }
-                        }
-                        if (media.prequel != null) {
-                            bind.mediaInfoPrequel.visibility = View.VISIBLE
-                            bind.mediaInfoPrequelImage.loadImage(
-                                media.prequel!!.banner ?: media.prequel!!.cover
-                            )
-                            bind.mediaInfoPrequel.setSafeOnClickListener {
-                                ContextCompat.startActivity(
-                                    requireContext(),
-                                    Intent(
+                                mediaInfoSequel.setSafeOnClickListener {
+                                    ContextCompat.startActivity(
                                         requireContext(),
-                                        MediaDetailsActivity::class.java
-                                    ).putExtra(
-                                        "media",
-                                        media.prequel as Serializable
-                                    ), null
-                                )
+                                        Intent(
+                                            requireContext(),
+                                            MediaDetailsActivity::class.java
+                                        ).putExtra(
+                                            "media",
+                                            media.sequel as Serializable
+                                        ), null
+                                    )
+                                }
                             }
+                            if (media.prequel != null) {
+                                mediaInfoPrequel.visibility = View.VISIBLE
+                                mediaInfoPrequelImage.loadImage(
+                                    media.prequel!!.banner ?: media.prequel!!.cover
+                                )
+                                mediaInfoPrequel.setSafeOnClickListener {
+                                    ContextCompat.startActivity(
+                                        requireContext(),
+                                        Intent(
+                                            requireContext(),
+                                            MediaDetailsActivity::class.java
+                                        ).putExtra(
+                                            "media",
+                                            media.prequel as Serializable
+                                        ), null
+                                    )
+                                }
+                            }
+                            parent.addView(root)
                         }
-                        parent.addView(bind.root)
+
+                        ItemTitleSearchBinding.inflate(
+                            LayoutInflater.from(context),
+                            parent,
+                            false
+                        ).apply {
+
+                            titleSearchImage.loadImage(media.banner ?: media.cover)
+                            titleSearchText.text =
+                                getString(R.string.search_title, media.mainName())
+                            titleSearchCard.setSafeOnClickListener {
+                                val query = Intent(requireContext(), SearchActivity::class.java)
+                                    .putExtra("type", "ANIME")
+                                    .putExtra("query", media.mainName())
+                                    .putExtra("search", true)
+                                ContextCompat.startActivity(requireContext(), query, null)
+                            }
+
+                            parent.addView(root)
+                        }
                     }
 
-                    val bindi = ItemTitleRecyclerBinding.inflate(
+                    ItemTitleRecyclerBinding.inflate(
                         LayoutInflater.from(context),
                         parent,
                         false
-                    )
+                    ).apply {
 
-                    bindi.itemRecycler.adapter =
-                        MediaAdaptor(0, media.relations!!, requireActivity())
-                    bindi.itemRecycler.layoutManager = LinearLayoutManager(
-                        requireContext(),
-                        LinearLayoutManager.HORIZONTAL,
-                        false
-                    )
-                    parent.addView(bindi.root)
+                        itemRecycler.adapter =
+                            MediaAdaptor(0, media.relations!!, requireActivity())
+                        itemRecycler.layoutManager = LinearLayoutManager(
+                            requireContext(),
+                            LinearLayoutManager.HORIZONTAL,
+                            false
+                        )
+                        parent.addView(root)
+                    }
                 }
                 if (!media.characters.isNullOrEmpty() && !offline) {
-                    val bind = ItemTitleRecyclerBinding.inflate(
+                    ItemTitleRecyclerBinding.inflate(
                         LayoutInflater.from(context),
                         parent,
                         false
-                    )
-                    bind.itemTitle.setText(R.string.characters)
-                    bind.itemRecycler.adapter =
-                        CharacterAdapter(media.characters!!)
-                    bind.itemRecycler.layoutManager = LinearLayoutManager(
-                        requireContext(),
-                        LinearLayoutManager.HORIZONTAL,
-                        false
-                    )
-                    parent.addView(bind.root)
+                    ).apply {
+                        itemTitle.setText(R.string.characters)
+                        itemRecycler.adapter =
+                            CharacterAdapter(media.characters!!)
+                        itemRecycler.layoutManager = LinearLayoutManager(
+                            requireContext(),
+                            LinearLayoutManager.HORIZONTAL,
+                            false
+                        )
+                        parent.addView(root)
+                    }
                 }
                 if (!media.staff.isNullOrEmpty() && !offline) {
-                    val bind = ItemTitleRecyclerBinding.inflate(
+                    ItemTitleRecyclerBinding.inflate(
                         LayoutInflater.from(context),
                         parent,
                         false
-                    )
-                    bind.itemTitle.setText(R.string.staff)
-                    bind.itemRecycler.adapter =
-                        AuthorAdapter(media.staff!!)
-                    bind.itemRecycler.layoutManager = LinearLayoutManager(
-                        requireContext(),
-                        LinearLayoutManager.HORIZONTAL,
-                        false
-                    )
-                    parent.addView(bind.root)
+                    ).apply {
+                        itemTitle.setText(R.string.staff)
+                        itemRecycler.adapter =
+                            AuthorAdapter(media.staff!!)
+                        itemRecycler.layoutManager = LinearLayoutManager(
+                            requireContext(),
+                            LinearLayoutManager.HORIZONTAL,
+                            false
+                        )
+                        parent.addView(root)
+                    }
                 }
                 if (!media.recommendations.isNullOrEmpty() && !offline) {
-                    val bind = ItemTitleRecyclerBinding.inflate(
+                    ItemTitleRecyclerBinding.inflate(
                         LayoutInflater.from(context),
                         parent,
                         false
-                    )
-                    bind.itemTitle.setText(R.string.recommended)
-                    bind.itemRecycler.adapter =
-                        MediaAdaptor(0, media.recommendations!!, requireActivity())
-                    bind.itemRecycler.layoutManager = LinearLayoutManager(
-                        requireContext(),
-                        LinearLayoutManager.HORIZONTAL,
-                        false
-                    )
-                    parent.addView(bind.root)
+                    ).apply {
+                        itemTitle.setText(R.string.recommended)
+                        itemRecycler.adapter =
+                            MediaAdaptor(0, media.recommendations!!, requireActivity())
+                        itemRecycler.layoutManager = LinearLayoutManager(
+                            requireContext(),
+                            LinearLayoutManager.HORIZONTAL,
+                            false
+                        )
+                        parent.addView(root)
+                    }
                 }
             }
         }
@@ -569,6 +594,7 @@ class MediaInfoFragment : Fragment() {
                 }
             }
         }
+
         super.onViewCreated(view, null)
     }
 

--- a/app/src/main/java/ani/dantotsu/media/SearchActivity.kt
+++ b/app/src/main/java/ani/dantotsu/media/SearchActivity.kt
@@ -70,6 +70,7 @@ class SearchActivity : AppCompatActivity() {
                 intent.getStringExtra("type") ?: "ANIME",
                 isAdult = if (Anilist.adult) intent.getBooleanExtra("hentai", false) else false,
                 onList = listOnly,
+                search = intent.getStringExtra("query"),
                 genres = intent.getStringExtra("genre")?.let { mutableListOf(it) },
                 tags = intent.getStringExtra("tag")?.let { mutableListOf(it) },
                 sort = intent.getStringExtra("sortBy"),

--- a/app/src/main/res/layout/fragment_media_info.xml
+++ b/app/src/main/res/layout/fragment_media_info.xml
@@ -26,10 +26,7 @@
                 style="?android:attr/progressBarStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="32dp"
-                android:layout_marginTop="32dp"
-                android:layout_marginEnd="32dp"
-                android:layout_marginBottom="32dp"
+                android:layout_margin="32dp"
                 android:indeterminate="true"
                 android:visibility="gone"
                 tools:visibility="gone" />
@@ -42,15 +39,12 @@
                 android:visibility="gone"
                 tools:visibility="visible">
 
-
-
                 <TableLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:orientation="vertical"
-                    android:paddingStart="32dp"
+                    android:paddingHorizontal="32dp"
                     android:paddingTop="16dp"
-                    android:paddingEnd="32dp"
                     android:paddingBottom="16dp">
 
                     <TableRow
@@ -397,8 +391,7 @@
                     android:id="@+id/mediaInfoDescriptionText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="32dp"
-                    android:layout_marginEnd="32dp"
+                    android:layout_marginHorizontal="32dp"
                     android:fontFamily="@font/poppins_bold"
                     android:text="@string/description"
                     android:textSize="16sp" />
@@ -407,8 +400,7 @@
                     android:id="@+id/mediaInfoDescription"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginEnd="16dp"
+                    android:layout_marginHorizontal="16dp"
                     android:ellipsize="end"
                     android:maxLines="5"
                     android:padding="16dp"

--- a/app/src/main/res/layout/item_quels.xml
+++ b/app/src/main/res/layout/item_quels.xml
@@ -5,9 +5,8 @@
     android:id="@+id/mediaInfoQuelContainer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginStart="24dp"
     android:layout_marginTop="8dp"
-    android:layout_marginEnd="24dp"
+    android:layout_marginHorizontal="24dp"
     android:layout_marginBottom="16dp">
 
     <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/item_title_search.xml
+++ b/app/src/main/res/layout/item_title_search.xml
@@ -1,0 +1,67 @@
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/titleSearchContainer"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginTop="8dp"
+    android:layout_marginHorizontal="24dp"
+    android:layout_marginBottom="16dp">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/titleSearchCard"
+        android:layout_width="match_parent"
+        android:layout_height="72dp"
+        android:layout_margin="8dp"
+        app:cardCornerRadius="16dp"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageView
+            android:id="@+id/titleSearchImage"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            tools:ignore="ContentDescription"
+            tools:src="@tools:sample/backgrounds/scenic" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:alpha="0.75"
+            android:background="@color/bg_black" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/titleSearchText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="4dp"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:maxLines="2"
+                android:ellipsize="end"
+                android:fontFamily="@font/poppins_bold"
+                android:text="@string/search"
+                android:textAllCaps="true"
+                android:textColor="@color/bg_white"
+                android:textSize="14sp" />
+
+            <View
+                android:layout_width="64dp"
+                android:layout_height="2dp"
+                android:layout_gravity="center"
+                android:background="?attr/colorSecondary" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -823,6 +823,8 @@ Non quae tempore quo provident laudantium qui illo dolor vel quia dolor et exerc
     <string name="do_it">Do it!</string>
     <string name="password">Password</string>
 
+    <string name="search_title">Search %1$s</string>
+
     <string name="profile_stats_widget">Track progress directly from your home screen</string>
     <string name="anime_watched">Anime\nWatched</string>
     <string name="manga_read">Manga\nRead</string>


### PR DESCRIPTION
This is a compromise between systematically tracing a season in both directions to find all prequels / sequels and scraping third-party sources in https://github.com/rebelonion/Dantotsu/issues/301 using search. It even keeps things pretty by presenting it as an actual search, rather than simply performing the query directly