### PR TITLE
fix: automate getting contributions

### DIFF
--- a/app/src/main/java/ani/dantotsu/connections/github/Contributors.kt
+++ b/app/src/main/java/ani/dantotsu/connections/github/Contributors.kt
@@ -1,0 +1,84 @@
+package ani.dantotsu.connections.github
+
+import ani.dantotsu.Mapper
+import ani.dantotsu.R
+import ani.dantotsu.client
+import ani.dantotsu.getAppString
+import ani.dantotsu.settings.Developer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.decodeFromJsonElement
+
+class Contributors {
+
+    fun getContributors(): Array<Developer> {
+        var developers = arrayOf<Developer>()
+        runBlocking(Dispatchers.IO) {
+            val repo = getAppString(R.string.repo)
+            val res = client.get("https://api.github.com/repos/$repo/contributors")
+                .parsed<JsonArray>().map {
+                    Mapper.json.decodeFromJsonElement<GithubResponse>(it)
+                }
+            res.find { it.login == "rebelonion"}?.let { first ->
+                developers = developers.plus(
+                    Developer(
+                        first.login,
+                        first.avatarUrl,
+                         "Owner and Maintainer",
+                        first.htmlUrl
+                    )
+                ).plus(arrayOf(
+                    Developer(
+                        "Wai What",
+                        "https://avatars.githubusercontent.com/u/149729762?v=4",
+                        "Icon Designer",
+                        "https://github.com/WaiWhat"
+                    ),
+                    Developer(
+                        "MarshMeadow",
+                        "https://avatars.githubusercontent.com/u/88599122?v=4",
+                        "Beta Icon Designer",
+                        "https://github.com/MarshMeadow?tab=repositories"
+                    ),
+                    Developer(
+                        "Zaxx69",
+                        "https://avatars.githubusercontent.com/u/138523882?v=4",
+                        "Telegram Admin",
+                        "https://github.com/Zaxx69"
+                    ),
+                    Developer(
+                        "Arif Alam",
+                        "https://avatars.githubusercontent.com/u/70383209?v=4",
+                        "Head Discord Moderator",
+                        "https://youtube.com/watch?v=dQw4w9WgXcQ"
+                    )
+                ))
+            }
+            res.filter {it.login != "rebelonion"}.forEach {
+                developers = developers.plus(
+                    Developer(
+                        it.login,
+                        it.avatarUrl,
+                        "Contributor",
+                        it.htmlUrl
+                    )
+                )
+            }
+        }
+        return developers
+    }
+
+
+    @Serializable
+    data class GithubResponse(
+        @SerialName("login")
+        val login: String,
+        @SerialName("avatar_url")
+        val avatarUrl: String,
+        @SerialName("html_url")
+        val htmlUrl: String
+    )
+}

--- a/app/src/main/java/ani/dantotsu/settings/DevelopersDialogFragment.kt
+++ b/app/src/main/java/ani/dantotsu/settings/DevelopersDialogFragment.kt
@@ -6,68 +6,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import ani.dantotsu.BottomSheetDialogFragment
+import ani.dantotsu.connections.github.Contributors
 import ani.dantotsu.databinding.BottomSheetDevelopersBinding
 
 class DevelopersDialogFragment : BottomSheetDialogFragment() {
     private var _binding: BottomSheetDevelopersBinding? = null
     private val binding get() = _binding!!
-
-    private val developers = arrayOf(
-        Developer(
-            "rebelonion",
-            "https://avatars.githubusercontent.com/u/87634197?v=4",
-            "Owner and Maintainer",
-            "https://github.com/rebelonion"
-        ),
-        Developer(
-            "Aayush262",
-            "https://avatars.githubusercontent.com/u/99584765?v=4",
-            "Contributor",
-            "https://github.com/aayush2622"
-        ),
-        Developer(
-            "Ibo",
-            "https://avatars.githubusercontent.com/u/41344259?v=4",
-            "Contributor",
-            "https://github.com/sneazy-ibo"
-        ),
-        Developer(
-            "AbandonedCart",
-            "https://avatars.githubusercontent.com/u/1173913?v=4",
-            "Contributor",
-            "https://github.com/AbandonedCart"
-        ),
-        Developer(
-            "Sadwhy",
-            "https://avatars.githubusercontent.com/u/99601717?v=4",
-            "Contributor",
-            "https://github.com/Sadwhy"
-        ),
-        Developer(
-            "Wai What",
-            "https://avatars.githubusercontent.com/u/149729762?v=4",
-            "Icon Designer",
-            "https://github.com/WaiWhat"
-        ),
-        Developer(
-            "MarshMeadow",
-            "https://avatars.githubusercontent.com/u/88599122?v=4",
-            "Beta Icon Designer",
-            "https://github.com/MarshMeadow?tab=repositories"
-        ),
-        Developer(
-            "Zaxx69",
-            "https://avatars.githubusercontent.com/u/138523882?v=4",
-            "Telegram Admin",
-            "https://github.com/Zaxx69"
-        ),
-        Developer(
-            "Arif Alam",
-            "https://avatars.githubusercontent.com/u/70383209?v=4",
-            "Head Discord Moderator",
-            "https://youtube.com/watch?v=dQw4w9WgXcQ"
-        ),
-    )
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -80,7 +24,7 @@ class DevelopersDialogFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.devsRecyclerView.adapter = DevelopersAdapter(developers)
+        binding.devsRecyclerView.adapter = DevelopersAdapter(Contributors().getContributors())
         binding.devsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
     }
 


### PR DESCRIPTION
 It would be nice if the site_admin flag worked for the repo owner, but it's a known value.

GitHub API is on par with some of the best in the world, and here we are doing one-off insertions. Seems silly, right?