### PR TITLE
fix: fix the fix for MangaUpdates

### DIFF
--- a/app/src/main/java/ani/dantotsu/Functions.kt
+++ b/app/src/main/java/ani/dantotsu/Functions.kt
@@ -993,12 +993,7 @@ fun countDown(media: Media, view: ViewGroup) {
 fun sinceWhen(media: Media, view: ViewGroup) {
     CoroutineScope(Dispatchers.IO).launch {
         MangaUpdates().search(media.name ?: media.nameRomaji, media.startDate)?.let {
-            val latestChapter = it.metadata.series.latestChapter ?: it.record.chapter?.let { chapter ->
-                if (chapter.contains("-"))
-                    chapter.split("-")[1].trim()
-                else
-                    chapter
-            }?.toIntOrNull() ?: return@launch
+            val latestChapter = MangaUpdates.getLatestChapter(it)
             val timeSince = (System.currentTimeMillis() -
                     (it.metadata.series.lastUpdated!!.timestamp * 1000)) / 1000
 

--- a/app/src/main/java/ani/dantotsu/connections/bakaupdates/MangaUpdates.kt
+++ b/app/src/main/java/ani/dantotsu/connections/bakaupdates/MangaUpdates.kt
@@ -34,8 +34,18 @@ class MangaUpdates {
                 }
             }
             val res = client.post(apiUrl, json = query).parsed<MangaUpdatesResponse>()
-            res.results?.forEach{ println("MangaUpdates: $it") }
-            res.results?.first { it.metadata.series.lastUpdated?.timestamp != null }
+            res.results?.first {
+                it.metadata.series.lastUpdated?.timestamp != null
+                        && (it.metadata.series.latestChapter != null
+                        || (it.record.volume.isNullOrBlank() && it.record.chapter != null))
+            }
+        }
+    }
+
+    companion object {
+        fun getLatestChapter(results: MangaUpdatesResponse.Results): Int {
+            return results.metadata.series.latestChapter
+                ?: results.record.chapter!!.substringAfterLast("-").trim().toInt()
         }
     }
 


### PR DESCRIPTION
The API is somewhat broken. If the latest chapter were ever filled, that would be awesome. Then you have random volumes showing up as the first result, but they are 100 chapters behind. In one case, the chapter number was a float. Basically, that leaves you wanting an item that has a release date filled in and either has a value that pretty much never exists or at least is a chapter not part of volume.