### PR TITLE
Fix : replaced the old rpc link

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="login">Login</string>
     <string name="logout">Logout</string>
 
-    <string name="dantotsu" translatable="false">https://dantotsu.app/</string>
+    <string name="dantotsu" translatable="false">https://dantotsuweb.vercel.app/</string>
     <string name="discord" translatable="false">https://discord.gg/4HPZ5nAWwM</string>
     <string name="github" translatable="false">https://github.com/rebelonion/Dantotsu</string>
     <string name="telegram" translatable="false" tools:ignore="Typos">https://t.me/+gzBCQExtLQo1YTNh </string>


### PR DESCRIPTION
I've changed the link in strings.xml to redirect to the [streaming](https://dantotsuweb.vercel.app/) site from discord rpc instead of redirecting to [old](https://dantotsu.app) url , this would make the " Read on dantotsu " & "Watch on dantotsu" buttons redirect to the new site url 