### PR TITLE
fix: remove unneeded (& problematic) logs

### DIFF
--- a/app/src/main/java/ani/dantotsu/parsers/AniyomiAdapter.kt
+++ b/app/src/main/java/ani/dantotsu/parsers/AniyomiAdapter.kt
@@ -348,9 +348,6 @@ class DynamicMangaParser(extension: MangaExtension.Installed) : MangaParser() {
             val res = source.getChapterList(sManga)
             val reversedRes = res.reversed()
             val chapterList = reversedRes.map { sChapterToMangaChapter(it) }
-            Logger.log("chapterList size: ${chapterList.size}")
-            Logger.log("chapterList: ${chapterList[1].title}")
-            Logger.log("chapterList: ${chapterList[1].description}")
             chapterList
         } catch (e: Exception) {
             Logger.log("loadChapters Exception: $e")


### PR DESCRIPTION
Removes hard-coded array access (that can crash) for logs that are no longer needed.