### PR TITLE
fix: deletion queries

### DIFF
--- a/app/src/main/java/ani/dantotsu/media/MediaListDialogFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/MediaListDialogFragment.kt
@@ -271,29 +271,23 @@ class MediaListDialogFragment : BottomSheetDialogFragment() {
                 }
 
                 binding.mediaListDelete.setOnClickListener {
-                    var id = media!!.userListId
                     scope.launch {
-                        withContext(Dispatchers.IO) {
-                            if (id != null) {
-                                Anilist.mutation.deleteList(id!!)
-                                MAL.query.deleteList(media?.anime != null, media?.idMAL)
-                            } else {
-                                val profile = Anilist.query.userMediaDetails(media!!)
-                                profile.userListId?.let { listId ->
-                                    id = listId
-                                    Anilist.mutation.deleteList(listId)
-                                    MAL.query.deleteList(media?.anime != null, media?.idMAL)
-                                }
+                        media?.deleteFromList(scope, onSuccess = {
+                            Refresh.all()
+                            snackString(getString(R.string.deleted_from_list))
+                            dismissAllowingStateLoss()
+                        }, onError = { e ->
+                            withContext(Dispatchers.Main) {
+                                snackString(
+                                    getString(
+                                        R.string.delete_fail_reason, e.message
+                                    )
+                                )
                             }
-                        }
-                        PrefManager.setCustomVal("removeList", removeList.minus(media?.id))
-                    }
-                    if (id != null) {
-                        Refresh.all()
-                        snackString(getString(R.string.deleted_from_list))
-                        dismissAllowingStateLoss()
-                    } else {
-                        snackString(getString(R.string.no_list_id))
+                        }, onNotFound = {
+                            snackString(getString(R.string.no_list_id))
+                        })
+
                     }
                 }
             }

--- a/app/src/main/java/ani/dantotsu/media/MediaListDialogSmallFragment.kt
+++ b/app/src/main/java/ani/dantotsu/media/MediaListDialogSmallFragment.kt
@@ -63,36 +63,24 @@ class MediaListDialogSmallFragment : BottomSheetDialogFragment() {
         binding.mediaListContainer.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin += navBarHeight }
         val scope = viewLifecycleOwner.lifecycleScope
         binding.mediaListDelete.setOnClickListener {
-            var id = media.userListId
             viewLifecycleOwner.lifecycleScope.launch {
-                withContext(Dispatchers.IO) {
-                    if (id != null) {
-                        try {
-                            Anilist.mutation.deleteList(id!!)
-                            MAL.query.deleteList(media.anime != null, media.idMAL)
-                        } catch (e: Exception) {
-                            withContext(Dispatchers.Main) {
-                                snackString(getString(R.string.delete_fail_reason, e.message))
-                            }
-                            return@withContext
-                        }
-                    } else {
-                        val profile = Anilist.query.userMediaDetails(media)
-                        profile.userListId?.let { listId ->
-                            id = listId
-                            Anilist.mutation.deleteList(listId)
-                            MAL.query.deleteList(media.anime != null, media.idMAL)
-                        }
-                    }
-                }
-                withContext(Dispatchers.Main) {
-                    if (id != null) {
+                scope.launch {
+                    media.deleteFromList(scope, onSuccess = {
                         Refresh.all()
                         snackString(getString(R.string.deleted_from_list))
                         dismissAllowingStateLoss()
-                    } else {
+                    }, onError = { e ->
+                        withContext(Dispatchers.Main) {
+                            snackString(
+                                getString(
+                                    R.string.delete_fail_reason, e.message
+                                )
+                            )
+                        }
+                    }, onNotFound = {
                         snackString(getString(R.string.no_list_id))
-                    }
+                    })
+
                 }
             }
         }


### PR DESCRIPTION
Rather than dismissing and removing all of the state for the queries before even confirming that they've finished (interesting idea @rebelonion), the dismissal only happens upon success.